### PR TITLE
Add Contacts Thought iOS-style PWA trick

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
       <button class="xl" data-href="tricks/swipe/settings.html">Swipe Input</button>
       <button class="xl" data-href="contained-swipe.html">Contained Swipe Input</button>
       <button class="xl" data-href="tricks/hangman/draw.html">Hangman Drawing</button>
+      <button class="xl" data-href="tricks/contacts-thought/index.html">Contacts Thought</button>
     </div>
     
     <h2>Tools</h2>

--- a/tricks/contacts-thought/app.js
+++ b/tricks/contacts-thought/app.js
@@ -1,0 +1,155 @@
+// Performer-controlled force data (used in order of opened contacts)
+const FORCED_CONTACT_DATA = [
+  { phone: '(212) 555-0146', email: 'northstar@icloud.com', birthday: 'March 14' },
+  { phone: '(917) 555-0192', email: 'velvetroom@me.com', birthday: 'August 22' },
+  { phone: '(646) 555-0118', email: 'midnightlane@gmail.com', birthday: 'December 5' }
+];
+
+const CONTACT_NAMES = [
+  'Aaron Adams', 'Abigail Allen', 'Aiden Archer', 'Alicia Avery',
+  'Bella Brooks', 'Ben Bennett', 'Bianca Byrd', 'Brandon Blake',
+  'Caleb Cole', 'Caroline Cruz', 'Carter Cain', 'Chloe Clarke',
+  'Daniel Diaz', 'Daphne Dunn', 'David Doyle', 'Dylan Drake',
+  'Eleanor Evans', 'Eli Ellis', 'Emma Everett', 'Ethan Easton',
+  'Felix Flores', 'Fiona Ford', 'Franklin Fry', 'Freya Finch',
+  'Gabriel Gray', 'Grace Green', 'Gwen Gallagher', 'Gavin Gale',
+  'Hannah Hayes', 'Harper Hill', 'Henry Holt', 'Hudson Hart',
+  'Ian Irwin', 'Iris Ingram', 'Isaac Iverson', 'Ivy Innes',
+  'Jack Jensen', 'Jade Jordan', 'James Jarvis', 'Julia Jensen',
+  'Kai Keller', 'Kara Knight', 'Keegan Knox', 'Kyra Kent',
+  'Landon Lane', 'Laura Lewis', 'Leo Logan', 'Lila Lambert',
+  'Mason Moore', 'Maya Miller', 'Mila Monroe', 'Miles Mercer',
+  'Nadia Nelson', 'Nathan Nash', 'Nina Novak', 'Noah Neal',
+  'Olivia Owen', 'Oscar Ortiz', 'Owen Oliver', 'Opal Ochoa',
+  'Parker Pierce', 'Paula Page', 'Peyton Price', 'Phoebe Park',
+  'Quentin Quinn', 'Queenie Quade',
+  'Riley Ross', 'Ruby Rivers', 'Ryan Rhodes', 'Ruth Reed',
+  'Sage Sutton', 'Samuel Shaw', 'Scarlett Stone', 'Sebastian Sloan',
+  'Taylor Tate', 'Theo Turner', 'Tristan Todd', 'Tessa Travis',
+  'Uma Underwood', 'Uriel Urban',
+  'Valerie Vaughn', 'Victor Vega', 'Violet Vance',
+  'Wesley White', 'Willow West', 'Wyatt Walsh',
+  'Xander Xu', 'Xenia Xavier',
+  'Yara Young', 'Yosef York',
+  'Zane Zimmerman', 'Zoe Zeller'
+].sort((a, b) => a.localeCompare(b));
+
+const listView = document.getElementById('listView');
+const alphaIndex = document.getElementById('alphaIndex');
+const searchInput = document.getElementById('searchInput');
+const detailView = document.getElementById('detailView');
+const detailName = document.getElementById('detailName');
+const detailPhone = document.getElementById('detailPhone');
+const detailEmail = document.getElementById('detailEmail');
+const detailBirthday = document.getElementById('detailBirthday');
+const detailCard = document.getElementById('detailCard');
+const loadingCard = document.getElementById('loadingCard');
+const backBtn = document.getElementById('backBtn');
+
+const sessionState = {
+  openedCount: 0
+};
+
+function buildGroupedContacts(query = '') {
+  const normalized = query.trim().toLowerCase();
+  const filtered = normalized
+    ? CONTACT_NAMES.filter((name) => name.toLowerCase().includes(normalized))
+    : CONTACT_NAMES;
+
+  const groups = new Map();
+  filtered.forEach((name) => {
+    const letter = name[0].toUpperCase();
+    if (!groups.has(letter)) groups.set(letter, []);
+    groups.get(letter).push(name);
+  });
+
+  return groups;
+}
+
+function renderList(query = '') {
+  const groups = buildGroupedContacts(query);
+  listView.innerHTML = '';
+  alphaIndex.innerHTML = '';
+
+  if (groups.size === 0) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No Contacts';
+    empty.style.padding = '20px 16px';
+    empty.style.color = '#6e6e73';
+    listView.appendChild(empty);
+    return;
+  }
+
+  groups.forEach((names, letter) => {
+    const section = document.createElement('section');
+    section.id = `section-${letter}`;
+
+    const header = document.createElement('h3');
+    header.className = 'section-header';
+    header.textContent = letter;
+    section.appendChild(header);
+
+    names.forEach((name) => {
+      const btn = document.createElement('button');
+      btn.className = 'contact-row';
+      btn.textContent = name;
+      btn.type = 'button';
+      btn.addEventListener('click', () => openContact(name));
+      section.appendChild(btn);
+    });
+
+    listView.appendChild(section);
+
+    if (!query.trim()) {
+      const indexBtn = document.createElement('button');
+      indexBtn.type = 'button';
+      indexBtn.textContent = letter;
+      indexBtn.addEventListener('click', () => {
+        document.getElementById(`section-${letter}`)?.scrollIntoView({ block: 'start' });
+      });
+      alphaIndex.appendChild(indexBtn);
+    }
+  });
+}
+
+function getForcedDataForOpenCount(openedCount) {
+  const forceIndex = Math.min(openedCount - 1, FORCED_CONTACT_DATA.length - 1);
+  return FORCED_CONTACT_DATA[forceIndex];
+}
+
+function openContact(name) {
+  sessionState.openedCount += 1;
+  const forced = getForcedDataForOpenCount(sessionState.openedCount);
+
+  detailName.textContent = name;
+  detailCard.classList.add('hidden');
+  loadingCard.classList.remove('hidden');
+  detailView.classList.remove('hidden');
+
+  setTimeout(() => {
+    detailPhone.textContent = forced.phone;
+    detailEmail.textContent = forced.email;
+    detailBirthday.textContent = forced.birthday;
+
+    loadingCard.classList.add('hidden');
+    detailCard.classList.remove('hidden');
+  }, 700);
+}
+
+backBtn.addEventListener('click', () => {
+  detailView.classList.add('hidden');
+  detailCard.classList.add('hidden');
+  loadingCard.classList.add('hidden');
+});
+
+searchInput.addEventListener('input', (e) => {
+  renderList(e.target.value);
+});
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js').catch(() => {});
+  });
+}
+
+renderList();

--- a/tricks/contacts-thought/icons/icon-192.svg
+++ b/tricks/contacts-thought/icons/icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <rect width="192" height="192" rx="42" fill="#f2f2f7"/>
+  <circle cx="96" cy="73" r="30" fill="#8e8e93"/>
+  <rect x="44" y="112" width="104" height="48" rx="24" fill="#8e8e93"/>
+</svg>

--- a/tricks/contacts-thought/icons/icon-512.svg
+++ b/tricks/contacts-thought/icons/icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" rx="112" fill="#f2f2f7"/>
+  <circle cx="256" cy="194" r="82" fill="#8e8e93"/>
+  <rect x="116" y="295" width="280" height="136" rx="68" fill="#8e8e93"/>
+</svg>

--- a/tricks/contacts-thought/index.html
+++ b/tricks/contacts-thought/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="default">
+  <meta name="theme-color" content="#f2f2f7">
+  <title>Contacts</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="apple-touch-icon" href="icons/icon-192.svg">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="app" aria-label="Contacts app">
+    <header class="topbar">
+      <h1>Contacts</h1>
+    </header>
+
+    <div class="search-wrap">
+      <label for="searchInput" class="sr-only">Search contacts</label>
+      <input id="searchInput" type="search" placeholder="Search" autocomplete="off">
+    </div>
+
+    <section id="listView" class="list-view" aria-label="Contact list"></section>
+
+    <aside id="alphaIndex" class="alpha-index" aria-label="Alphabet index"></aside>
+
+    <section id="detailView" class="detail-view hidden" aria-live="polite" aria-label="Contact details">
+      <div class="detail-header">
+        <button id="backBtn" class="back-btn" aria-label="Back to contacts">‹ Contacts</button>
+        <h2 id="detailName"></h2>
+      </div>
+
+      <div id="loadingCard" class="loading-card hidden" aria-hidden="true">
+        <div class="shimmer-line w40"></div>
+        <div class="shimmer-line"></div>
+        <div class="shimmer-line"></div>
+        <div class="shimmer-line w70"></div>
+      </div>
+
+      <div id="detailCard" class="detail-card hidden">
+        <div class="action-row">
+          <button class="action">call</button>
+          <button class="action">message</button>
+          <button class="action">FaceTime</button>
+          <button class="action">mail</button>
+        </div>
+
+        <div class="info-group">
+          <p class="label">phone</p>
+          <p id="detailPhone" class="value"></p>
+        </div>
+
+        <div class="info-group">
+          <p class="label">email</p>
+          <p id="detailEmail" class="value"></p>
+        </div>
+
+        <div class="info-group">
+          <p class="label">birthday</p>
+          <p id="detailBirthday" class="value"></p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/tricks/contacts-thought/manifest.webmanifest
+++ b/tricks/contacts-thought/manifest.webmanifest
@@ -1,0 +1,22 @@
+{
+  "name": "Contacts",
+  "short_name": "Contacts",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#f2f2f7",
+  "theme_color": "#f2f2f7",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/tricks/contacts-thought/service-worker.js
+++ b/tricks/contacts-thought/service-worker.js
@@ -1,0 +1,28 @@
+const CACHE_NAME = 'contacts-thought-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './styles.css',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.svg',
+  './icons/icon-512.svg'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => Promise.all(
+      keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(caches.match(event.request).then((cached) => cached || fetch(event.request)));
+});

--- a/tricks/contacts-thought/styles.css
+++ b/tricks/contacts-thought/styles.css
@@ -1,0 +1,230 @@
+:root {
+  --bg: #f2f2f7;
+  --card: #ffffff;
+  --line: #d1d1d6;
+  --text: #000000;
+  --subtext: #6e6e73;
+  --ios-blue: #007aff;
+}
+
+* {
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+
+html,
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  overflow: hidden;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.app {
+  position: relative;
+  width: 100%;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.topbar {
+  background: var(--bg);
+  padding: max(10px, env(safe-area-inset-top)) 16px 10px;
+  border-bottom: 1px solid var(--line);
+}
+
+.topbar h1 {
+  font-size: 34px;
+  line-height: 1.1;
+  margin: 0;
+  font-weight: 700;
+}
+
+.search-wrap {
+  padding: 10px 16px 8px;
+  background: var(--bg);
+}
+
+#searchInput {
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 16px;
+  background: #e5e5ea;
+}
+
+#searchInput:focus {
+  outline: none;
+}
+
+.list-view {
+  overflow-y: auto;
+  height: calc(100dvh - 120px);
+  padding-bottom: max(16px, env(safe-area-inset-bottom));
+}
+
+.section-header {
+  padding: 8px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--subtext);
+  background: #ebebf0;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.contact-row {
+  width: 100%;
+  border: none;
+  background: var(--card);
+  border-bottom: 1px solid #efeff4;
+  text-align: left;
+  padding: 12px 16px;
+  font-size: 17px;
+  line-height: 1.3;
+}
+
+.alpha-index {
+  position: absolute;
+  right: 2px;
+  top: 132px;
+  bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+  width: 16px;
+  color: var(--ios-blue);
+  font-size: 11px;
+  font-weight: 500;
+  user-select: none;
+}
+
+.alpha-index button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  line-height: 1;
+}
+
+.detail-view {
+  position: absolute;
+  inset: 0;
+  background: var(--bg);
+  z-index: 20;
+  overflow-y: auto;
+}
+
+.hidden {
+  display: none;
+}
+
+.detail-header {
+  padding: max(10px, env(safe-area-inset-top)) 16px 8px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+}
+
+.back-btn {
+  border: none;
+  background: transparent;
+  color: var(--ios-blue);
+  font-size: 17px;
+  padding: 0;
+  margin-bottom: 12px;
+}
+
+.detail-header h2 {
+  margin: 0;
+  font-size: 32px;
+  font-weight: 700;
+}
+
+.loading-card,
+.detail-card {
+  margin: 16px;
+  background: var(--card);
+  border-radius: 14px;
+  border: 1px solid #ececf0;
+  overflow: hidden;
+}
+
+.shimmer-line {
+  height: 18px;
+  margin: 14px;
+  border-radius: 8px;
+  background: linear-gradient(100deg, #f5f5f7 20%, #ececf0 40%, #f5f5f7 60%);
+  background-size: 200% 100%;
+  animation: shimmer 1.1s infinite;
+}
+
+.w40 { width: 40%; }
+.w70 { width: 70%; }
+
+@keyframes shimmer {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
+}
+
+.action-row {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  padding: 12px;
+  border-bottom: 1px solid #efeff4;
+}
+
+.action {
+  background: #f7f7fa;
+  border: 1px solid #ececf0;
+  color: var(--ios-blue);
+  font-size: 13px;
+  border-radius: 10px;
+  padding: 8px 2px;
+  text-transform: lowercase;
+}
+
+.info-group {
+  padding: 12px 14px;
+  border-bottom: 1px solid #efeff4;
+}
+
+.info-group:last-child {
+  border-bottom: none;
+}
+
+.label {
+  margin: 0 0 4px;
+  color: var(--subtext);
+  font-size: 13px;
+  text-transform: lowercase;
+}
+
+.value {
+  margin: 0;
+  font-size: 17px;
+  color: var(--text);
+}


### PR DESCRIPTION
### Motivation
- Provide a handheld magic trick that perfectly mimics the iOS Contacts app UI while allowing the performer to force three predetermined contact detail sets during a spectator session.
- Make the trick portable and believable by packaging it as a small installable PWA with icons and an offline service worker.

### Description
- Added a new app at `tricks/contacts-thought/` including `index.html`, `styles.css`, `app.js`, `manifest.webmanifest`, `service-worker.js`, and app icons to reproduce the iOS Contacts look and behavior.
- Implemented the hidden forcing mechanic in `app.js` where `FORCED_CONTACT_DATA` (configured at the top of the file) is applied based on the in-session opened count: first open → set #1, second → set #2, third and later → set #3, while always showing the chosen contact name.
- Added a loading shimmer in the detail view to sell a realistic data fetch before forced details appear and included a search bar, alphabetical sections, and a right-side A–Z index to match the real Contacts app.
- Wired a launcher button into the main `index.html` so the new trick appears in the project's home UI.

### Testing
- Ran a static syntax check with `node --check tricks/contacts-thought/app.js`, which completed successfully.
- Served the project locally using `python -m http.server 4173` and validated the UI flow in a headless browser run with Playwright, producing a screenshot of the detail view (success).
- Verified service worker and manifest files are present and the app loads assets; no automated failures were observed during these checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac8795f1b08332a095a50ac0c9f3cc)