### PR TITLE
Add iPhone Mirage trick with settings/perform UI, logic, and assets; link from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
     <h2>Tricks</h2>
     <div class="stack">
       <button class="xl" data-href="tricks/swipe/settings.html">Swipe Input</button>
+      <button class="xl" data-href="tricks/iphone-mirage/settings.html">iPhone Mirage Trick</button>
       <button class="xl" data-href="contained-swipe.html">Contained Swipe Input</button>
       <button class="xl" data-href="tricks/hangman/draw.html">Hangman Drawing</button>
       <button class="xl" data-href="tricks/contacts-thought/index.html">Contacts Thought</button>

--- a/tricks/iphone-mirage/README.md
+++ b/tricks/iphone-mirage/README.md
@@ -1,0 +1,25 @@
+# iPhone Mirage Trick
+
+This trick simulates an iPhone-style home screen with hidden settings access.
+
+## Preview
+
+### Settings
+![Settings preview](./preview-settings.svg)
+
+### Perform Mode
+![Perform preview](./preview-perform.svg)
+
+## Hidden settings gesture
+1. Long-press the **Clock** icon for at least 1 second.
+2. Tap the top-left corner 3 times quickly.
+
+## Trick flow
+1. In **Settings**, assign a value to any app icon.
+2. Pick a trigger app (the app that ends input and copies the result).
+3. In **Perform**, tap app icons to build a string (e.g. `3` then `4` → `34`).
+4. Tap the trigger app to copy the full result to clipboard.
+5. Paste into the clipboard verification field in Settings to confirm.
+
+
+> Note: These are lightweight static previews checked into the repo so links never break in PR/comment contexts.

--- a/tricks/iphone-mirage/app.js
+++ b/tricks/iphone-mirage/app.js
@@ -1,0 +1,313 @@
+const APP_KEY = 'iphoneMirage';
+
+const APP_CATALOG = [
+  { id: 'calendar', label: 'Calendar', glyph: '17', color: 'linear-gradient(#fff,#f0f0f0)', page: 0 },
+  { id: 'photos', label: 'Photos', glyph: '✿', color: 'linear-gradient(140deg,#ffd25c,#ff6b6b,#a16bff)', page: 0 },
+  { id: 'camera', label: 'Camera', glyph: '◉', color: 'linear-gradient(#5d5d5d,#2c2c2c)', page: 0 },
+  { id: 'mail', label: 'Mail', glyph: '✉', color: 'linear-gradient(#4ab4ff,#0a6fff)', page: 0 },
+  { id: 'maps', label: 'Maps', glyph: '🗺', color: 'linear-gradient(#5be7ff,#53da77)', page: 0 },
+  { id: 'weather', label: 'Weather', glyph: '☀', color: 'linear-gradient(#5fbeff,#2f77ff)', page: 0 },
+  { id: 'clock', label: 'Clock', glyph: '🕒', color: 'linear-gradient(#2e2e2e,#111)', page: 0 },
+  { id: 'notes', label: 'Notes', glyph: '▤', color: 'linear-gradient(#fff38a,#f7d43f)', page: 0 },
+  { id: 'reminders', label: 'Reminders', glyph: '•', color: 'linear-gradient(#fff,#f0f0f0)', page: 1 },
+  { id: 'stocks', label: 'Stocks', glyph: '📈', color: 'linear-gradient(#1c1c1c,#000)', page: 1 },
+  { id: 'music', label: 'Music', glyph: '♪', color: 'linear-gradient(#ff5e8b,#ff255a)', page: 1 },
+  { id: 'podcasts', label: 'Podcasts', glyph: '◍', color: 'linear-gradient(#c774ff,#9a44ff)', page: 1 },
+  { id: 'youtube', label: 'YouTube', glyph: '▶', color: 'linear-gradient(#ff4a4a,#d60000)', page: 1 },
+  { id: 'instagram', label: 'Instagram', glyph: '◌', color: 'linear-gradient(135deg,#ffd86a,#ff4da0,#8a56ff)', page: 1 },
+  { id: 'tiktok', label: 'TikTok', glyph: '♪', color: 'linear-gradient(#252525,#000)', page: 1 },
+  { id: 'spotify', label: 'Spotify', glyph: '☊', color: 'linear-gradient(#1adb66,#169b47)', page: 1 },
+  { id: 'x', label: 'X', glyph: '𝕏', color: 'linear-gradient(#2a2a2a,#000)', page: 2 },
+  { id: 'facebook', label: 'Facebook', glyph: 'f', color: 'linear-gradient(#1877f2,#0f4fbf)', page: 2 },
+  { id: 'whatsapp', label: 'WhatsApp', glyph: '✆', color: 'linear-gradient(#42dd78,#0fb050)', page: 2 },
+  { id: 'netflix', label: 'Netflix', glyph: 'N', color: 'linear-gradient(#1c1c1c,#000)', page: 2 },
+  { id: 'uber', label: 'Uber', glyph: '⬢', color: 'linear-gradient(#343434,#090909)', page: 2 },
+  { id: 'airbnb', label: 'Airbnb', glyph: '⌂', color: 'linear-gradient(#ff778b,#ff355b)', page: 2 },
+  { id: 'chatgpt', label: 'ChatGPT', glyph: '✺', color: 'linear-gradient(#6df0c5,#1ea476)', page: 2 },
+  { id: 'calculator', label: 'Calculator', glyph: '±', color: 'linear-gradient(#444,#1b1b1b)', page: 2 },
+  { id: 'phone', label: 'Phone', glyph: '✆', color: 'linear-gradient(#58de6f,#0dad3f)', dock: true },
+  { id: 'safari', label: 'Safari', glyph: '🧭', color: 'linear-gradient(#66d9ff,#107dff)', dock: true },
+  { id: 'messages', label: 'Messages', glyph: '💬', color: 'linear-gradient(#60e87d,#2eb956)', dock: true },
+  { id: 'special', label: 'Utilities', glyph: '⚙', color: 'linear-gradient(#a8a8a8,#717171)', dock: true }
+];
+
+const DEFAULTS = {
+  wallpaper: '',
+  triggerAppId: 'special',
+  appValues: {},
+  currentResult: '',
+  clipboardProbe: ''
+};
+
+function loadState() {
+  const raw = Storage.load(APP_KEY, DEFAULTS) || {};
+  return {
+    ...DEFAULTS,
+    ...raw,
+    appValues: { ...(DEFAULTS.appValues || {}), ...(raw.appValues || {}) }
+  };
+}
+
+function saveState(state) {
+  Storage.save(APP_KEY, state);
+}
+
+function appById(id) {
+  return APP_CATALOG.find((app) => app.id === id);
+}
+
+function iconButton(app) {
+  const btn = document.createElement('button');
+  btn.className = 'icon-btn';
+  btn.dataset.appId = app.id;
+  btn.innerHTML = `
+    <span class="icon-tile" style="background:${app.color}">${app.glyph}</span>
+    <span class="icon-label">${app.label}</span>
+  `;
+  return btn;
+}
+
+function applyWallpaper(el, wallpaper) {
+  if (wallpaper) {
+    el.style.backgroundImage = `url(${wallpaper})`;
+    return;
+  }
+  el.style.backgroundImage = 'linear-gradient(150deg,#3355bb 0%,#7d57d8 35%,#df6f9f 100%)';
+}
+
+function initSettingsPage() {
+  const state = loadState();
+  const wallpaperInput = document.getElementById('wallpaperInput');
+  const triggerSelect = document.getElementById('triggerApp');
+  const appMap = document.getElementById('appMap');
+  const currentResult = document.getElementById('currentResult');
+  const clipboardProbe = document.getElementById('clipboardProbe');
+  const goPerform = document.getElementById('goPerform');
+  const resetBuffer = document.getElementById('resetBuffer');
+
+  APP_CATALOG.forEach((app) => {
+    const option = document.createElement('option');
+    option.value = app.id;
+    option.textContent = app.label;
+    triggerSelect.appendChild(option);
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'map-item';
+    const value = state.appValues[app.id] || '';
+    wrapper.innerHTML = `
+      <div class="map-title"><span>${app.glyph}</span><span>${app.label}</span></div>
+      <input type="text" data-map-input="${app.id}" placeholder="Value when tapped" value="${value}">
+    `;
+    appMap.appendChild(wrapper);
+  });
+
+  const hasTrigger = APP_CATALOG.some((app) => app.id === state.triggerAppId);
+  state.triggerAppId = hasTrigger ? state.triggerAppId : DEFAULTS.triggerAppId;
+  triggerSelect.value = state.triggerAppId;
+  currentResult.textContent = state.currentResult || '(empty)';
+  clipboardProbe.value = state.clipboardProbe || '';
+  saveState(state);
+
+  appMap.addEventListener('input', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || !target.dataset.mapInput) {
+      return;
+    }
+    state.appValues[target.dataset.mapInput] = target.value;
+    saveState(state);
+  });
+
+  triggerSelect.addEventListener('change', () => {
+    state.triggerAppId = triggerSelect.value;
+    saveState(state);
+  });
+
+  wallpaperInput.addEventListener('change', (event) => {
+    const file = event.target.files && event.target.files[0];
+    if (!file) {
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      state.wallpaper = reader.result;
+      saveState(state);
+    };
+    reader.readAsDataURL(file);
+  });
+
+  clipboardProbe.addEventListener('input', () => {
+    state.clipboardProbe = clipboardProbe.value;
+    saveState(state);
+  });
+
+  resetBuffer.addEventListener('click', () => {
+    state.currentResult = '';
+    currentResult.textContent = '(empty)';
+    saveState(state);
+  });
+
+  goPerform.addEventListener('click', () => {
+    window.location.href = './perform.html';
+  });
+}
+
+function initPerformPage() {
+  const state = loadState();
+  if (!APP_CATALOG.some((app) => app.id === state.triggerAppId)) {
+    state.triggerAppId = DEFAULTS.triggerAppId;
+    saveState(state);
+  }
+  let activePage = 0;
+  let collecting = true;
+  let buffer = state.currentResult || '';
+
+  const screen = document.getElementById('screen');
+  const pagesTrack = document.getElementById('pagesTrack');
+  const dock = document.getElementById('dock');
+  const pageDots = document.getElementById('pageDots');
+  const toast = document.getElementById('toast');
+  const timeEl = document.getElementById('time');
+
+  const maxPage = Math.max(...APP_CATALOG.filter((app) => !app.dock).map((app) => app.page));
+  applyWallpaper(screen, state.wallpaper);
+
+  const updateTime = () => {
+    timeEl.textContent = new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  };
+  updateTime();
+  setInterval(updateTime, 1000 * 30);
+
+  for (let i = 0; i <= maxPage; i += 1) {
+    const page = document.createElement('div');
+    page.className = 'page';
+    APP_CATALOG.filter((app) => app.page === i).forEach((app) => page.appendChild(iconButton(app)));
+    pagesTrack.appendChild(page);
+
+    const dot = document.createElement('span');
+    dot.className = `page-dot ${i === 0 ? 'active' : ''}`;
+    dot.dataset.dot = String(i);
+    pageDots.appendChild(dot);
+  }
+
+  APP_CATALOG.filter((app) => app.dock).forEach((app) => dock.appendChild(iconButton(app)));
+
+  const paintPage = () => {
+    pagesTrack.style.transform = `translateX(${-activePage * 100}%)`;
+    pageDots.querySelectorAll('.page-dot').forEach((dot) => {
+      dot.classList.toggle('active', Number(dot.dataset.dot) === activePage);
+    });
+  };
+
+  const emitToast = (message) => {
+    toast.textContent = message;
+    toast.classList.add('show');
+    window.clearTimeout(emitToast.timer);
+    emitToast.timer = window.setTimeout(() => toast.classList.remove('show'), 1200);
+  };
+
+  const persistResult = () => {
+    state.currentResult = buffer;
+    saveState(state);
+  };
+
+  const appendFromApp = (appId) => {
+    if (!collecting) {
+      emitToast('Sequence locked. Use your reset action in Settings.');
+      return;
+    }
+
+    if (appId === state.triggerAppId) {
+      collecting = false;
+      if (!navigator.clipboard || !navigator.clipboard.writeText) {
+        emitToast('Clipboard unavailable in this browser');
+      } else {
+        navigator.clipboard.writeText(buffer).then(() => {
+          emitToast(`Copied: ${buffer || '(empty)'}`);
+        }).catch(() => emitToast('Clipboard blocked by browser'));
+      }
+      persistResult();
+      return;
+    }
+
+    const chunk = state.appValues[appId];
+    if (!chunk) {
+      emitToast(`${appById(appId)?.label || 'App'} has no value assigned`);
+      return;
+    }
+
+    buffer += chunk;
+    persistResult();
+    emitToast(`Added ${chunk}`);
+  };
+
+  document.body.addEventListener('click', (event) => {
+    const button = event.target.closest('.icon-btn');
+    if (!button) {
+      return;
+    }
+    appendFromApp(button.dataset.appId);
+  });
+
+  let startX = 0;
+  let startY = 0;
+
+  document.getElementById('pagesViewport').addEventListener('touchstart', (event) => {
+    startX = event.touches[0].clientX;
+    startY = event.touches[0].clientY;
+  }, { passive: true });
+
+  document.getElementById('pagesViewport').addEventListener('touchend', (event) => {
+    const dx = event.changedTouches[0].clientX - startX;
+    const dy = Math.abs(event.changedTouches[0].clientY - startY);
+    if (Math.abs(dx) < 28 || dy > 50) {
+      return;
+    }
+    activePage += dx > 0 ? -1 : 1;
+    activePage = Math.max(0, Math.min(maxPage, activePage));
+    paintPage();
+  }, { passive: true });
+
+  // Secret access flow: long-press Clock icon then tap top-left corner 3 times quickly.
+  let armedUntil = 0;
+  let cornerTapCount = 0;
+
+  document.body.addEventListener('pointerdown', (event) => {
+    const button = event.target.closest('.icon-btn');
+    if (!button || button.dataset.appId !== 'clock') {
+      return;
+    }
+    const begin = Date.now();
+    const clear = () => {
+      document.body.removeEventListener('pointerup', clear);
+      document.body.removeEventListener('pointercancel', clear);
+      if (Date.now() - begin >= 1100) {
+        armedUntil = Date.now() + 2500;
+        cornerTapCount = 0;
+        emitToast('Access armed');
+      }
+    };
+    document.body.addEventListener('pointerup', clear);
+    document.body.addEventListener('pointercancel', clear);
+  });
+
+  document.getElementById('settingsHotspot').addEventListener('click', () => {
+    if (Date.now() > armedUntil) {
+      return;
+    }
+    cornerTapCount += 1;
+    if (cornerTapCount >= 3) {
+      window.location.href = './settings.html';
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const page = document.body.dataset.page;
+  if (page === 'settings') {
+    initSettingsPage();
+    return;
+  }
+  if (page === 'perform') {
+    initPerformPage();
+  }
+});

--- a/tricks/iphone-mirage/perform.html
+++ b/tricks/iphone-mirage/perform.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <title>iPhone Mirage Perform</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body data-page="perform">
+  <div id="screen" class="screen">
+    <div class="scrim"></div>
+    <div class="dynamic-island"></div>
+    <div class="status-bar">
+      <span id="time">9:41</span>
+      <span>5G 🔋</span>
+    </div>
+
+    <div id="pagesViewport" class="pages-viewport">
+      <div id="pagesTrack" class="pages-track"></div>
+    </div>
+
+    <div id="pageDots" class="page-dots"></div>
+    <div id="dock" class="dock"></div>
+    <div id="toast" class="toast"></div>
+    <div id="settingsHotspot" class="hidden-hotspot" aria-hidden="true"></div>
+    <div class="home-indicator"></div>
+  </div>
+
+  <script src="../../assets/js/storage.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/tricks/iphone-mirage/preview-perform.svg
+++ b/tricks/iphone-mirage/preview-perform.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="430" height="932" viewBox="0 0 430 932">
+  <defs>
+    <linearGradient id="wall" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#3355bb"/>
+      <stop offset="0.5" stop-color="#7d57d8"/>
+      <stop offset="1" stop-color="#df6f9f"/>
+    </linearGradient>
+  </defs>
+  <rect width="430" height="932" fill="url(#wall)"/>
+  <rect x="153" y="12" width="124" height="34" rx="17" fill="#000"/>
+  <text x="24" y="35" fill="#fff" font-size="16" font-family="-apple-system,Segoe UI,sans-serif">9:41</text>
+  <text x="355" y="35" fill="#fff" font-size="16">5G 🔋</text>
+  <g font-family="-apple-system,Segoe UI,sans-serif" text-anchor="middle" fill="#fff">
+    <g>
+      <rect x="24" y="88" width="74" height="74" rx="18" fill="#ffffff"/><text x="61" y="134" fill="#111" font-size="26">17</text><text x="61" y="178" font-size="12">Calendar</text>
+      <rect x="124" y="88" width="74" height="74" rx="18" fill="#ff6b6b"/><text x="161" y="134" font-size="26">✿</text><text x="161" y="178" font-size="12">Photos</text>
+      <rect x="224" y="88" width="74" height="74" rx="18" fill="#2c2c2c"/><text x="261" y="134" font-size="26">◉</text><text x="261" y="178" font-size="12">Camera</text>
+      <rect x="324" y="88" width="74" height="74" rx="18" fill="#0a6fff"/><text x="361" y="134" font-size="26">✉</text><text x="361" y="178" font-size="12">Mail</text>
+    </g>
+  </g>
+  <circle cx="205" cy="760" r="3.5" fill="#fff" opacity=".7"/>
+  <circle cx="219" cy="760" r="3.5" fill="#fff" opacity=".3"/>
+  <circle cx="233" cy="760" r="3.5" fill="#fff" opacity=".3"/>
+  <rect x="8" y="788" width="414" height="106" rx="30" fill="rgba(255,255,255,.25)"/>
+  <g text-anchor="middle" fill="#fff" font-size="12" font-family="-apple-system,Segoe UI,sans-serif">
+    <rect x="34" y="804" width="74" height="74" rx="18" fill="#0dad3f"/><text x="71" y="848" font-size="26">✆</text><text x="71" y="888">Phone</text>
+    <rect x="132" y="804" width="74" height="74" rx="18" fill="#107dff"/><text x="169" y="848" font-size="26">🧭</text><text x="169" y="888">Safari</text>
+    <rect x="230" y="804" width="74" height="74" rx="18" fill="#2eb956"/><text x="267" y="848" font-size="26">💬</text><text x="267" y="888">Messages</text>
+    <rect x="328" y="804" width="74" height="74" rx="18" fill="#717171"/><text x="365" y="848" font-size="26">⚙</text><text x="365" y="888">Utilities</text>
+  </g>
+  <rect x="145" y="918" width="140" height="5" rx="3" fill="#fff"/>
+</svg>

--- a/tricks/iphone-mirage/preview-settings.svg
+++ b/tricks/iphone-mirage/preview-settings.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="430" height="932" viewBox="0 0 430 932">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#1e2947"/>
+      <stop offset="1" stop-color="#0b1123"/>
+    </linearGradient>
+  </defs>
+  <rect width="430" height="932" fill="url(#bg)"/>
+  <text x="24" y="56" fill="#fff" font-size="28" font-family="-apple-system,Segoe UI,sans-serif">iPhone Mirage — Settings</text>
+  <rect x="16" y="88" width="398" height="122" rx="16" fill="#121a35" stroke="#2d3968"/>
+  <text x="30" y="120" fill="#cfe0ff" font-size="15">Wallpaper image (optional)</text>
+  <rect x="30" y="136" width="370" height="46" rx="10" fill="#0c1430" stroke="#3a4d86"/>
+  <rect x="16" y="224" width="398" height="128" rx="16" fill="#121a35" stroke="#2d3968"/>
+  <text x="30" y="256" fill="#fff" font-size="20">Capture behavior</text>
+  <text x="30" y="286" fill="#cfe0ff" font-size="14">Trigger app: Utilities</text>
+  <rect x="16" y="366" width="398" height="300" rx="16" fill="#121a35" stroke="#2d3968"/>
+  <text x="30" y="398" fill="#fff" font-size="20">App value map</text>
+  <g fill="#0f1834" stroke="#304278">
+    <rect x="30" y="420" width="178" height="68" rx="12"/>
+    <rect x="222" y="420" width="178" height="68" rx="12"/>
+    <rect x="30" y="500" width="178" height="68" rx="12"/>
+    <rect x="222" y="500" width="178" height="68" rx="12"/>
+  </g>
+  <rect x="16" y="680" width="398" height="200" rx="16" fill="#121a35" stroke="#2d3968"/>
+  <text x="30" y="714" fill="#fff" font-size="20">Debug and verification</text>
+  <text x="30" y="744" fill="#98f8c5" font-size="15">Current captured input: 34</text>
+  <rect x="30" y="758" width="370" height="66" rx="10" fill="#0c1430" stroke="#3a4d86"/>
+</svg>

--- a/tricks/iphone-mirage/settings.html
+++ b/tricks/iphone-mirage/settings.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, user-scalable=no">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <title>iPhone Mirage Settings</title>
+  <link rel="stylesheet" href="./styles.css">
+</head>
+<body data-page="settings">
+  <main class="settings-shell">
+    <section class="settings-card">
+      <h1>iPhone Mirage — Settings</h1>
+      <p>Upload your iPhone 15 Pro Max wallpaper screenshot, assign values to each icon, and pick the trigger app that copies the captured sequence.</p>
+      <label for="wallpaperInput">Wallpaper image (optional)</label>
+      <input id="wallpaperInput" type="file" accept="image/*">
+    </section>
+
+    <section class="settings-card">
+      <h2>Capture behavior</h2>
+      <label for="triggerApp">Trigger app (copies the current captured value to clipboard)</label>
+      <select id="triggerApp"></select>
+      <p style="font-size:12px;margin-top:8px">Secret access from Perform mode: long-press <strong>Clock</strong> for 1+ second, then tap the top-left corner 3 times.</p>
+    </section>
+
+    <section class="settings-card">
+      <h2>App value map</h2>
+      <div id="appMap" class="app-map"></div>
+    </section>
+
+    <section class="settings-card">
+      <h2>Debug and verification</h2>
+      <p>Current captured input: <span id="currentResult" class="result-pill">(empty)</span></p>
+      <label for="clipboardProbe">Clipboard verification field (paste here after trigger app)</label>
+      <textarea id="clipboardProbe" rows="3" placeholder="Paste clipboard result here to verify"></textarea>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:10px">
+        <button id="resetBuffer" type="button">Reset captured input</button>
+        <button id="goPerform" type="button">Open Perform Mode</button>
+      </div>
+    </section>
+  </main>
+
+  <script src="../../assets/js/storage.js"></script>
+  <script src="./app.js"></script>
+</body>
+</html>

--- a/tricks/iphone-mirage/styles.css
+++ b/tricks/iphone-mirage/styles.css
@@ -1,0 +1,246 @@
+:root {
+  --glass: rgba(18, 22, 41, 0.55);
+  --text: #f8f9ff;
+}
+
+html, body {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", "Helvetica Neue", sans-serif;
+  background: #000;
+  color: var(--text);
+}
+
+.screen {
+  position: fixed;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.scrim {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.3), rgba(0, 0, 0, 0.05) 30%, rgba(0, 0, 0, 0.18));
+}
+
+.status-bar {
+  position: absolute;
+  top: max(8px, env(safe-area-inset-top));
+  left: 16px;
+  right: 16px;
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  font-weight: 600;
+  z-index: 4;
+  pointer-events: none;
+}
+
+.dynamic-island {
+  position: absolute;
+  top: max(8px, env(safe-area-inset-top));
+  left: 50%;
+  transform: translateX(-50%);
+  width: 124px;
+  height: 34px;
+  border-radius: 20px;
+  background: #000;
+  z-index: 3;
+}
+
+.pages-viewport {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: max(56px, calc(env(safe-area-inset-top) + 46px));
+  bottom: calc(132px + env(safe-area-inset-bottom));
+  overflow: hidden;
+  z-index: 2;
+}
+
+.pages-track {
+  display: flex;
+  height: 100%;
+  transition: transform 260ms ease;
+}
+
+.page {
+  min-width: 100%;
+  padding: 10px 18px;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 20px 10px;
+  align-content: start;
+}
+
+.icon-btn {
+  border: 0;
+  background: none;
+  color: #fff;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.65);
+  display: grid;
+  justify-items: center;
+  gap: 7px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.icon-tile {
+  width: min(74px, 17vw);
+  aspect-ratio: 1;
+  border-radius: 18px;
+  display: grid;
+  place-items: center;
+  font-size: 30px;
+  font-weight: 700;
+  box-shadow: 0 8px 14px rgba(0, 0, 0, 0.32);
+}
+
+.icon-label {
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.dock {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: calc(26px + env(safe-area-inset-bottom));
+  min-height: 92px;
+  border-radius: 30px;
+  background: rgba(255, 255, 255, 0.2);
+  backdrop-filter: blur(14px);
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  align-items: center;
+  padding: 12px 8px 8px;
+  z-index: 3;
+}
+
+.page-dots {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: calc(120px + env(safe-area-inset-bottom));
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  z-index: 3;
+}
+
+.page-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.32);
+}
+
+.page-dot.active { background: rgba(255, 255, 255, 0.85); }
+
+.toast {
+  position: absolute;
+  bottom: calc(182px + env(safe-area-inset-bottom));
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(20, 22, 28, 0.86);
+  font-size: 13px;
+  opacity: 0;
+  transition: opacity 180ms ease;
+  z-index: 5;
+}
+
+.toast.show { opacity: 1; }
+
+.home-indicator {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 140px;
+  height: 5px;
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.9);
+  bottom: max(8px, env(safe-area-inset-bottom));
+  z-index: 3;
+}
+
+.hidden-hotspot {
+  position: absolute;
+  width: 80px;
+  height: 80px;
+  top: 0;
+  left: 0;
+  z-index: 6;
+}
+
+/* Settings page */
+.settings-shell {
+  height: 100%;
+  overflow-y: auto;
+  background: radial-gradient(circle at top, #1e2947, #0b1123 48%);
+  padding: max(20px, env(safe-area-inset-top)) 16px max(24px, env(safe-area-inset-bottom));
+}
+
+.settings-card {
+  border: 1px solid #2d3968;
+  border-radius: 16px;
+  background: #121a35;
+  padding: 14px;
+  margin-bottom: 12px;
+}
+
+h1, h2 { margin: 0 0 10px; }
+
+label { display: block; font-size: 13px; color: #c9d3f3; margin-bottom: 6px; }
+
+input, select, textarea, button {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid #3a4d86;
+  background: #0c1430;
+  color: #fff;
+  padding: 10px;
+  font-size: 14px;
+}
+
+button {
+  background: linear-gradient(90deg, #7fd7ff, #76f6ba);
+  border: 0;
+  color: #071320;
+  font-weight: 700;
+}
+
+.app-map {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.map-item {
+  border: 1px solid #304278;
+  border-radius: 12px;
+  padding: 8px;
+  background: #0f1834;
+}
+
+.map-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  margin-bottom: 6px;
+}
+
+.result-pill {
+  display: inline-block;
+  font-weight: 700;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #0d2a1d;
+  color: #98f8c5;
+}


### PR DESCRIPTION
### Motivation
- Add a new interactive trick that simulates an iPhone-style home screen with configurable app values and a hidden settings access gesture for demos and tricks. 
- Provide both a Settings and Perform mode so users can assign values to icons and capture sequences that are copied to the clipboard via a trigger app. 

### Description
- Add a new `tricks/iphone-mirage` feature folder containing `settings.html`, `perform.html`, `styles.css`, `app.js`, preview SVGs, and a `README.md` describing the trick and the hidden gesture. 
- Implement app state persistence and UI logic in `app.js`, including an app catalog, wallpaper handling, value mapping, trigger app behavior, clipboard copy flow, paging/docking UI, and the secret long-press + corner-tap access to Settings. 
- Add lightweight static previews (`preview-settings.svg`, `preview-perform.svg`) and a README for stable links in PRs and comments. 
- Update `index.html` to surface the new trick by adding an "iPhone Mirage Trick" button to the Tricks section and keep script navigation behavior intact. 

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac915f4f4c8332b7e126bb3ad79d5f)