### PR TITLE
Add mobile-first Stack Sprint PWA for memorized deck training

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ Interactive drawing trick for the classic hangman game.
 ### Time Travel
 A time manipulation utility.
 
+### Card Stack Trainer
+A colorful PWA trainer for memorized deck work with two-way recall drills, adaptive weak-spot practice, and progress statistics.
+
+- **Location**: `tools/card-stack-trainer/`
+- **Modes**:
+  - Number → Card
+  - Card → Number
+  - Mixed adaptive drills
+  - Stack Explorer
+  - Progress dashboard
+
 ### Simple PWA Demo
 Demonstrates Progressive Web App capabilities.
 
@@ -236,6 +247,7 @@ Magic-Ideas/
 │   │   └── perform.html
 │   └── hangman/                  # Hangman drawing
 ├── tools/
+│   ├── card-stack-trainer/       # Memorized deck PWA trainer
 │   └── time-travel/              # Time travel utility
 ├── gesture-input-demo.html       # Interactive demo of gesture input modes
 ├── contained-swipe.html          # Contained swipe variant

--- a/tools/card-stack-trainer/app.js
+++ b/tools/card-stack-trainer/app.js
@@ -1,0 +1,317 @@
+(() => {
+  'use strict';
+
+  const STACK = [
+    'AH','KS','AD','KC','2H','QS','2D','QC','3H','JS','3D','JC','4H','TS','4D','TC',
+    '5H','9S','5D','9C','6H','8S','6D','8C','7H','7S','7D','7C','8H','6S','8D','6C',
+    '9H','5S','9D','5C','TH','4S','TD','4C','JH','3S','JD','3C','QH','2S','QD','2C',
+    'KH','AS','KD','AC'
+  ];
+
+  const cardToNumber = new Map(STACK.map((card, i) => [card, i + 1]));
+
+  const state = {
+    mode: null,
+    currentPrompt: null,
+    startedAt: 0,
+    stats: loadStats(),
+    sessionCorrect: 0,
+    sessionTotal: 0,
+    currentStreak: 0,
+  };
+
+  const els = {
+    modeGrid: document.getElementById('modeGrid'),
+    trainer: document.getElementById('trainer'),
+    review: document.getElementById('review'),
+    stats: document.getElementById('stats'),
+    streakChip: document.getElementById('streakChip'),
+    btnBack: document.getElementById('btnBack'),
+    btnBackReview: document.getElementById('btnBackReview'),
+    btnBackStats: document.getElementById('btnBackStats'),
+    scoreline: document.getElementById('scoreline'),
+    questionLabel: document.getElementById('questionLabel'),
+    questionValue: document.getElementById('questionValue'),
+    timerValue: document.getElementById('timerValue'),
+    answerForm: document.getElementById('answerForm'),
+    answerInput: document.getElementById('answerInput'),
+    answerLabel: document.getElementById('answerLabel'),
+    feedback: document.getElementById('feedback'),
+    btnReveal: document.getElementById('btnReveal'),
+    btnNext: document.getElementById('btnNext'),
+    stackGrid: document.getElementById('stackGrid'),
+    statAttempts: document.getElementById('statAttempts'),
+    statAccuracy: document.getElementById('statAccuracy'),
+    statSpeed: document.getElementById('statSpeed'),
+    statBestStreak: document.getElementById('statBestStreak'),
+    weakList: document.getElementById('weakList'),
+    btnReset: document.getElementById('btnReset'),
+  };
+
+  const timer = setInterval(() => {
+    if (!state.startedAt || els.trainer.classList.contains('hidden')) return;
+    const seconds = (performance.now() - state.startedAt) / 1000;
+    els.timerValue.textContent = `${seconds.toFixed(1)}s`;
+  }, 80);
+
+  function normalizeCard(value) {
+    return value.trim().toUpperCase().replace('10', 'T');
+  }
+
+  function loadStats() {
+    const defaults = {
+      attempts: 0,
+      correct: 0,
+      totalMs: 0,
+      bestStreak: 0,
+      missed: {},
+      mastered: {},
+    };
+    try {
+      const raw = localStorage.getItem('stackSprintStats');
+      return raw ? { ...defaults, ...JSON.parse(raw) } : defaults;
+    } catch {
+      return defaults;
+    }
+  }
+
+  function persistStats() {
+    localStorage.setItem('stackSprintStats', JSON.stringify(state.stats));
+  }
+
+  function updateTopStatsUI() {
+    const pct = state.sessionTotal ? Math.round((state.sessionCorrect / state.sessionTotal) * 100) : 0;
+    els.scoreline.textContent = `${state.sessionCorrect} / ${state.sessionTotal} • ${pct}%`;
+    els.streakChip.textContent = `Streak: ${state.currentStreak} 🔥`;
+  }
+
+  function setView(name) {
+    els.modeGrid.classList.toggle('hidden', name !== 'modes');
+    els.trainer.classList.toggle('hidden', name !== 'trainer');
+    els.review.classList.toggle('hidden', name !== 'review');
+    els.stats.classList.toggle('hidden', name !== 'stats');
+  }
+
+  function weightedRandomPrompt(direction) {
+    const pool = STACK.map((card, idx) => {
+      const key = `${idx + 1}:${card}`;
+      const misses = state.stats.missed[key] || 0;
+      const masteredPenalty = state.stats.mastered[key] ? 0.4 : 1;
+      const weight = Math.max(1, misses * 1.8) * masteredPenalty;
+      return { idx, card, weight };
+    });
+
+    const totalWeight = pool.reduce((sum, item) => sum + item.weight, 0);
+    let roll = Math.random() * totalWeight;
+    for (const item of pool) {
+      roll -= item.weight;
+      if (roll <= 0) {
+        return direction === 'number-to-card'
+          ? { ask: String(item.idx + 1), answer: item.card, key: `${item.idx + 1}:${item.card}` }
+          : { ask: item.card, answer: String(item.idx + 1), key: `${item.idx + 1}:${item.card}` };
+      }
+    }
+    return { ask: '1', answer: 'AH', key: '1:AH' };
+  }
+
+  function nextPrompt() {
+    let direction = state.mode;
+    if (direction === 'mixed') {
+      direction = Math.random() < 0.5 ? 'number-to-card' : 'card-to-number';
+    }
+
+    state.currentPrompt = weightedRandomPrompt(direction);
+    state.startedAt = performance.now();
+
+    const isNumberAsk = direction === 'number-to-card';
+    els.questionLabel.textContent = isNumberAsk ? 'Position' : 'Card';
+    els.questionValue.textContent = state.currentPrompt.ask;
+    els.answerLabel.textContent = isNumberAsk ? 'Enter card (e.g. 5H)' : 'Enter position (1-52)';
+    els.answerInput.value = '';
+    els.answerInput.inputMode = isNumberAsk ? 'text' : 'numeric';
+    els.answerInput.focus();
+    els.feedback.classList.add('hidden');
+    els.btnNext.classList.remove('pulse');
+    els.timerValue.textContent = '0.0s';
+  }
+
+  function evaluate(answerRaw) {
+    const prompt = state.currentPrompt;
+    if (!prompt) return;
+
+    const elapsedMs = performance.now() - state.startedAt;
+    const expected = /^\d+$/.test(prompt.answer) ? prompt.answer : normalizeCard(prompt.answer);
+    const actual = /^\d+$/.test(prompt.answer) ? answerRaw.trim() : normalizeCard(answerRaw);
+    const correct = actual === expected;
+
+    state.sessionTotal += 1;
+    state.stats.attempts += 1;
+    state.stats.totalMs += elapsedMs;
+
+    if (correct) {
+      state.sessionCorrect += 1;
+      state.stats.correct += 1;
+      state.currentStreak += 1;
+      state.stats.bestStreak = Math.max(state.stats.bestStreak, state.currentStreak);
+      els.feedback.innerHTML = `✅ Correct. <strong>${prompt.ask}</strong> ↔ <strong>${prompt.answer}</strong>`;
+      els.feedback.className = 'feedback correct';
+      if ((state.stats.missed[prompt.key] || 0) > 0) {
+        state.stats.missed[prompt.key] -= 1;
+      }
+    } else {
+      state.currentStreak = 0;
+      state.stats.missed[prompt.key] = (state.stats.missed[prompt.key] || 0) + 1;
+      els.feedback.innerHTML = `❌ Not this time. Correct answer: <strong>${prompt.answer}</strong>`;
+      els.feedback.className = 'feedback wrong';
+    }
+
+    persistStats();
+    updateTopStatsUI();
+    els.btnNext.classList.add('pulse');
+  }
+
+  function buildExplorer() {
+    els.stackGrid.innerHTML = '';
+    STACK.forEach((card, idx) => {
+      const n = idx + 1;
+      const key = `${n}:${card}`;
+      const tile = document.createElement('button');
+      tile.className = 'stack-tile';
+      tile.type = 'button';
+      tile.innerHTML = `
+        <span class="front">#${n}</span>
+        <span class="back">${card}</span>
+        <span class="star">${state.stats.mastered[key] ? '⭐' : '☆'}</span>
+      `;
+      tile.addEventListener('click', (e) => {
+        if (e.target.classList.contains('star')) return;
+        tile.classList.toggle('flipped');
+      });
+      tile.querySelector('.star').addEventListener('click', (e) => {
+        e.stopPropagation();
+        state.stats.mastered[key] = !state.stats.mastered[key];
+        persistStats();
+        buildExplorer();
+      });
+      els.stackGrid.appendChild(tile);
+    });
+  }
+
+  function renderStats() {
+    const attempts = state.stats.attempts;
+    const accuracy = attempts ? Math.round((state.stats.correct / attempts) * 100) : 0;
+    const avg = attempts ? state.stats.totalMs / attempts / 1000 : 0;
+
+    els.statAttempts.textContent = String(attempts);
+    els.statAccuracy.textContent = `${accuracy}%`;
+    els.statSpeed.textContent = `${avg.toFixed(1)}s`;
+    els.statBestStreak.textContent = String(state.stats.bestStreak);
+
+    const weakPairs = Object.entries(state.stats.missed)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 8);
+
+    els.weakList.innerHTML = '';
+    if (!weakPairs.length) {
+      const li = document.createElement('li');
+      li.textContent = 'No weak spots yet — keep drilling!';
+      els.weakList.appendChild(li);
+      return;
+    }
+
+    weakPairs.forEach(([key, misses]) => {
+      const [num, card] = key.split(':');
+      const li = document.createElement('li');
+      li.textContent = `#${num} ↔ ${card} missed ${misses} time${misses === 1 ? '' : 's'}`;
+      els.weakList.appendChild(li);
+    });
+  }
+
+  function setupEvents() {
+    document.querySelectorAll('.mode-card').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const mode = btn.dataset.mode;
+        state.mode = mode;
+        if (mode === 'review') {
+          buildExplorer();
+          setView('review');
+          return;
+        }
+        if (mode === 'stats') {
+          renderStats();
+          setView('stats');
+          return;
+        }
+        state.sessionCorrect = 0;
+        state.sessionTotal = 0;
+        state.currentStreak = 0;
+        updateTopStatsUI();
+        setView('trainer');
+        nextPrompt();
+      });
+    });
+
+    [els.btnBack, els.btnBackReview, els.btnBackStats].forEach((btn) => {
+      btn.addEventListener('click', () => {
+        state.startedAt = 0;
+        setView('modes');
+      });
+    });
+
+    els.answerForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      evaluate(els.answerInput.value);
+    });
+
+    els.btnReveal.addEventListener('click', () => {
+      if (!state.currentPrompt) return;
+      els.feedback.innerHTML = `💡 Reveal: <strong>${state.currentPrompt.answer}</strong>`;
+      els.feedback.className = 'feedback reveal';
+    });
+
+    els.btnNext.addEventListener('click', nextPrompt);
+
+    els.btnReset.addEventListener('click', () => {
+      state.stats = {
+        attempts: 0,
+        correct: 0,
+        totalMs: 0,
+        bestStreak: 0,
+        missed: {},
+        mastered: {},
+      };
+      persistStats();
+      renderStats();
+      buildExplorer();
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (els.trainer.classList.contains('hidden')) return;
+      if (e.key === 'Enter' && document.activeElement !== els.answerInput) {
+        e.preventDefault();
+        evaluate(els.answerInput.value);
+      }
+      if (e.key.toLowerCase() === 'n') {
+        e.preventDefault();
+        nextPrompt();
+      }
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        els.btnReveal.click();
+      }
+    });
+  }
+
+  function registerServiceWorker() {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('service-worker.js').catch(() => {});
+    }
+  }
+
+  setupEvents();
+  updateTopStatsUI();
+  setView('modes');
+  registerServiceWorker();
+
+  window.addEventListener('beforeunload', () => clearInterval(timer));
+})();

--- a/tools/card-stack-trainer/icons/icon-192.svg
+++ b/tools/card-stack-trainer/icons/icon-192.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ba9cff"/>
+      <stop offset="100%" stop-color="#78ffd6"/>
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="38" fill="#1e0f46"/>
+  <rect x="36" y="26" width="120" height="140" rx="14" fill="url(#g)"/>
+  <text x="96" y="110" text-anchor="middle" font-size="56" font-family="Arial" font-weight="700" fill="#1e0f46">A♠</text>
+</svg>

--- a/tools/card-stack-trainer/icons/icon-512.svg
+++ b/tools/card-stack-trainer/icons/icon-512.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ba9cff"/>
+      <stop offset="100%" stop-color="#78ffd6"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="108" fill="#1e0f46"/>
+  <rect x="96" y="64" width="320" height="384" rx="40" fill="url(#g)"/>
+  <text x="256" y="300" text-anchor="middle" font-size="140" font-family="Arial" font-weight="700" fill="#1e0f46">A♠</text>
+</svg>

--- a/tools/card-stack-trainer/index.html
+++ b/tools/card-stack-trainer/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="theme-color" content="#2d1b69">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <title>Stack Sprint Trainer</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="apple-touch-icon" href="icons/icon-192.svg">
+  <link rel="stylesheet" href="../../assets/css/base.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <main class="container app-shell">
+    <header class="app-header">
+      <h1>🃏 Stack Sprint</h1>
+      <p class="subtitle">Train both directions: position → card and card → position.</p>
+      <div class="streak-chip" id="streakChip">Streak: 0 🔥</div>
+    </header>
+
+    <section class="mode-grid" id="modeGrid">
+      <button class="mode-card" data-mode="number-to-card">
+        <span class="mode-title"># → Card</span>
+        <span class="mode-copy">Given a number, recall the card</span>
+      </button>
+      <button class="mode-card" data-mode="card-to-number">
+        <span class="mode-title">Card → #</span>
+        <span class="mode-copy">Given a card, recall the number</span>
+      </button>
+      <button class="mode-card" data-mode="mixed">
+        <span class="mode-title">Mixed Drills</span>
+        <span class="mode-copy">Adaptive review of your weak spots</span>
+      </button>
+      <button class="mode-card ghost" data-mode="review">
+        <span class="mode-title">Stack Explorer</span>
+        <span class="mode-copy">Browse, reveal, and mark mastered cards</span>
+      </button>
+      <button class="mode-card ghost" data-mode="stats">
+        <span class="mode-title">Progress</span>
+        <span class="mode-copy">Accuracy, speed, weak cards, and trends</span>
+      </button>
+    </section>
+
+    <section class="trainer hidden" id="trainer">
+      <div class="quiz-head">
+        <button class="btn-back" id="btnBack">← Modes</button>
+        <div class="scoreline" id="scoreline">0 / 0 • 0%</div>
+      </div>
+
+      <div class="question-card" id="questionCard">
+        <div class="question-label" id="questionLabel">Position</div>
+        <div class="question-value" id="questionValue">17</div>
+        <div class="question-timer">⏱ <span id="timerValue">0.0s</span></div>
+      </div>
+
+      <form class="answer-form" id="answerForm" autocomplete="off">
+        <label for="answerInput" id="answerLabel">Enter card (e.g. 5H)</label>
+        <input id="answerInput" inputmode="text" autocapitalize="characters" spellcheck="false" required>
+        <button class="xl" type="submit">Check</button>
+      </form>
+
+      <div class="feedback hidden" id="feedback"></div>
+
+      <div class="actions-row">
+        <button class="ghost" id="btnReveal" type="button">Reveal</button>
+        <button class="ghost" id="btnNext" type="button">Next</button>
+      </div>
+    </section>
+
+    <section class="review hidden" id="review">
+      <div class="quiz-head">
+        <button class="btn-back" id="btnBackReview">← Modes</button>
+        <h2>Stack Explorer</h2>
+      </div>
+      <p class="subtitle">Tap a card to flip. Use the ⭐ to mark cards that feel automatic.</p>
+      <div class="stack-grid" id="stackGrid"></div>
+    </section>
+
+    <section class="stats hidden" id="stats">
+      <div class="quiz-head">
+        <button class="btn-back" id="btnBackStats">← Modes</button>
+        <h2>Progress</h2>
+      </div>
+      <div class="stats-grid">
+        <article class="stat-card"><h3>Total Attempts</h3><p id="statAttempts">0</p></article>
+        <article class="stat-card"><h3>Accuracy</h3><p id="statAccuracy">0%</p></article>
+        <article class="stat-card"><h3>Avg. Response</h3><p id="statSpeed">0.0s</p></article>
+        <article class="stat-card"><h3>Best Streak</h3><p id="statBestStreak">0</p></article>
+      </div>
+
+      <div class="weak-list-wrap">
+        <h3>Cards/Positions to Focus</h3>
+        <ul id="weakList"></ul>
+      </div>
+
+      <button class="ghost" id="btnReset">Reset Stats</button>
+    </section>
+  </main>
+
+  <script src="app.js"></script>
+</body>
+</html>

--- a/tools/card-stack-trainer/manifest.webmanifest
+++ b/tools/card-stack-trainer/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Stack Sprint Trainer",
+  "short_name": "Stack Sprint",
+  "description": "Mobile-first card stack memorization trainer with testing and progress tracking.",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#1e0f46",
+  "theme_color": "#2d1b69",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/tools/card-stack-trainer/service-worker.js
+++ b/tools/card-stack-trainer/service-worker.js
@@ -1,0 +1,39 @@
+const CACHE_NAME = 'stack-sprint-v1';
+const ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.svg',
+  './icons/icon-512.svg',
+  '../../assets/css/base.css'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) return cached;
+      return fetch(event.request).then((response) => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        return response;
+      }).catch(() => caches.match('./index.html'));
+    })
+  );
+});

--- a/tools/card-stack-trainer/style.css
+++ b/tools/card-stack-trainer/style.css
@@ -1,0 +1,199 @@
+:root {
+  --bg: linear-gradient(155deg, #1e0f46 0%, #13203d 42%, #07353a 100%);
+  --panel: rgba(12, 18, 42, 0.82);
+  --line: rgba(170, 192, 255, 0.25);
+  --text: #f4f7ff;
+  --muted: #c7d4ff;
+  --mint: #78ffd6;
+  --lav: #ba9cff;
+  --rose: #ff95b1;
+}
+
+body {
+  min-height: 100dvh;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-shell {
+  min-height: 100dvh;
+  padding-top: max(16px, env(safe-area-inset-top));
+  padding-bottom: max(20px, env(safe-area-inset-bottom));
+}
+
+.subtitle { color: var(--muted); }
+.hidden { display: none !important; }
+
+.app-header {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 18px;
+  backdrop-filter: blur(9px);
+}
+
+.streak-chip {
+  width: fit-content;
+  margin-top: 12px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-weight: 700;
+  background: linear-gradient(90deg, rgba(186, 156, 255, 0.25), rgba(120, 255, 214, 0.25));
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.mode-grid {
+  margin-top: 18px;
+  display: grid;
+  gap: 12px;
+}
+
+.mode-card {
+  text-align: left;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+  border-radius: 16px;
+  padding: 14px;
+}
+
+.mode-card.ghost { opacity: 0.92; }
+.mode-title { display: block; font-weight: 800; }
+.mode-copy { color: var(--muted); font-size: 0.92rem; }
+
+.quiz-head {
+  margin: 14px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.btn-back,
+.ghost,
+.xl {
+  border-radius: 12px;
+}
+
+.question-card {
+  background: radial-gradient(circle at 0 0, rgba(186, 156, 255, 0.4), rgba(0, 0, 0, 0) 50%), var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 20px;
+  padding: 24px;
+  text-align: center;
+  margin-bottom: 14px;
+}
+
+.question-label { color: var(--muted); }
+.question-value { font-size: 2.8rem; font-weight: 900; letter-spacing: 0.03em; }
+.question-timer { margin-top: 6px; color: var(--mint); font-weight: 700; }
+
+.answer-form {
+  display: grid;
+  gap: 10px;
+}
+
+.answer-form input {
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px solid var(--line);
+  background: rgba(255,255,255,0.08);
+  color: var(--text);
+  font-size: 1.2rem;
+}
+
+.feedback {
+  margin-top: 12px;
+  border-radius: 14px;
+  padding: 12px;
+  border: 1px solid transparent;
+  animation: fadeIn 160ms ease;
+}
+.feedback.correct { background: rgba(58, 255, 184, 0.15); border-color: rgba(120, 255, 214, 0.5); }
+.feedback.wrong { background: rgba(255, 100, 146, 0.15); border-color: rgba(255, 149, 177, 0.45); }
+.feedback.reveal { background: rgba(186, 156, 255, 0.2); border-color: rgba(186, 156, 255, 0.55); }
+
+.actions-row {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.stack-grid {
+  margin-top: 12px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stack-tile {
+  position: relative;
+  min-height: 84px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  color: var(--text);
+  overflow: hidden;
+}
+
+.stack-tile .front,
+.stack-tile .back {
+  display: grid;
+  place-items: center;
+  height: 100%;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+.stack-tile .back { opacity: 0; transform: translateY(8px); position: absolute; inset: 0; }
+.stack-tile.flipped .front { opacity: 0; transform: translateY(-8px); }
+.stack-tile.flipped .back { opacity: 1; transform: translateY(0); }
+.stack-tile .star {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  font-size: 1.2rem;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.stat-card {
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 12px;
+}
+
+.stat-card p {
+  margin: 4px 0 0;
+  font-size: 1.8rem;
+  font-weight: 900;
+  color: var(--mint);
+}
+
+.weak-list-wrap {
+  margin: 14px 0;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  padding: 12px;
+}
+
+#weakList {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--muted);
+}
+
+.pulse { animation: pulse 780ms ease-in-out infinite; }
+@keyframes pulse { 0%, 100% { transform: scale(1);} 50% { transform: scale(1.02);} }
+@keyframes fadeIn { from { opacity: 0; transform: translateY(4px);} to { opacity: 1; transform: translateY(0);} }
+
+@media (min-width: 600px) {
+  .mode-grid { grid-template-columns: 1fr 1fr; }
+  .stack-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+}


### PR DESCRIPTION
### Motivation
- Provide a mobile-first Progressive Web App that helps memorize a fixed 52-card stack with two-way recall for memorized-deck routines. 
- Enable fast drill loops, timed responses and reveal support so practice sessions map to real memorized-deck workflows. 
- Track persistent practice data and surface weak spots so the trainer adapts to the user and prioritizes items that need work. 

### Description
- Added a new PWA under `tools/card-stack-trainer/` including `index.html`, `app.js`, `style.css`, `manifest.webmanifest`, `service-worker.js`, and two SVG app icons. 
- Implemented the exact 52-card stack you provided in `app.js` and two-way drill logic for `number→card`, `card→number`, and a `mixed` adaptive mode with weighted selection based on misses. 
- Built a `Stack Explorer` with flip tiles and mastered markers, session scoring, timed response display, reveal/next controls, keyboard shortcuts, streaks, and UI feedback (correct/wrong). 
- Added persistent stats in `localStorage` (attempts, correct, total time, best streak, missed/mastered maps), subtle UI animations/styles in `style.css`, and offline/installable support via `manifest.webmanifest` and `service-worker.js`. 
- Updated `README.md` to document the new `tools/card-stack-trainer/` tool and reflect the project structure. 

### Testing
- Verified `tools/card-stack-trainer/app.js` syntax with `node --check` and it succeeded. 
- Verified `tools/card-stack-trainer/service-worker.js` syntax with `node --check` and it succeeded. 
- Validated `tools/card-stack-trainer/manifest.webmanifest` JSON with `python -m json.tool` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f03f5e57d8833283981816765e28c1)