### PR TITLE
Enhance Stack Memorizer with adaptive memory training controls

### DIFF
--- a/tools/card-stack-trainer/app.js
+++ b/tools/card-stack-trainer/app.js
@@ -49,7 +49,7 @@
   const SRS_KEY              = 'stackMemorizeSRS';
   const SRS_INTERVALS        = [1, 3, 7, 14, 30]; // days
   const MS_PER_DAY           = 86_400_000;
-  const SESSION_SIZE         = 10;
+  const SESSION_SIZE_DEFAULT = 10;
   const MAX_DUE_PER_SESSION  = 7;
   const MAX_REQUEUES         = 3;
 
@@ -105,17 +105,17 @@
     return STACK.filter((_, i) => !srs[i]).length;
   }
 
-  function buildSessionQueue(srs) {
+  function buildSessionQueue(srs, sessionSize) {
     const now = Date.now();
 
     const due = STACK
       .map((_, i) => ({ idx: i, due: srs[i] ? srs[i].due : Infinity }))
       .filter(c => srs[c.idx] && c.due <= now)
       .sort((a, b) => a.due - b.due)
-      .slice(0, MAX_DUE_PER_SESSION)
+      .slice(0, Math.min(MAX_DUE_PER_SESSION, sessionSize))
       .map(c => c.idx);
 
-    const remaining = SESSION_SIZE - due.length;
+    const remaining = sessionSize - due.length;
     const newCards  = STACK
       .map((_, i) => i)
       .filter(i => !srs[i])
@@ -140,7 +140,22 @@
     currentIdx:   null,
     srs:          null,
     agained:      {},   // idx → times re-queued this session (caps at 3)
+    seenSinceQuiz: 0,
+    quizEvery: 3,
+    pendingQuiz: null,
   };
+
+  const MEM_CFG_KEY = 'stackMemorizeConfig';
+  function loadMemConfig() {
+    try {
+      const raw = JSON.parse(localStorage.getItem(MEM_CFG_KEY) || '{}');
+      return {
+        batchSize: Math.min(20, Math.max(4, Number(raw.batchSize) || SESSION_SIZE_DEFAULT)),
+        quizEvery: Math.min(6, Math.max(2, Number(raw.quizEvery) || 3)),
+      };
+    } catch { return { batchSize: SESSION_SIZE_DEFAULT, quizEvery: 3 }; }
+  }
+  function saveMemConfig(cfg) { localStorage.setItem(MEM_CFG_KEY, JSON.stringify(cfg)); }
 
   /* ── DOM references ──────────────────────────────────────────── */
   const els = {
@@ -189,6 +204,11 @@
     memInfoDue:         document.getElementById('memInfoDue'),
     memInfoNew:         document.getElementById('memInfoNew'),
     memBtnStart:        document.getElementById('memBtnStart'),
+    memModeCopy:        document.getElementById('memModeCopy'),
+    memBatchSize:       document.getElementById('memBatchSize'),
+    memBatchValue:      document.getElementById('memBatchValue'),
+    memQuizEvery:       document.getElementById('memQuizEvery'),
+    memQuizEveryValue:  document.getElementById('memQuizEveryValue'),
     memStudyCard:       document.getElementById('memStudyCard'),
     memFaceNumber:      document.getElementById('memFaceNumber'),
     pcRank1:            document.getElementById('pcRank1'),
@@ -393,6 +413,12 @@
 
   /* ── Memorize — session ──────────────────────────────────────── */
   function openMemorize() {
+    const cfg = loadMemConfig();
+    els.memBatchSize.value = String(cfg.batchSize);
+    els.memBatchValue.textContent = String(cfg.batchSize);
+    els.memQuizEvery.value = String(cfg.quizEvery);
+    els.memQuizEveryValue.textContent = String(cfg.quizEvery);
+    els.memModeCopy.textContent = `${cfg.batchSize} cards · quiz every ${cfg.quizEvery}`;
     els.memInfoDue.textContent = String(srsDueCount());
     els.memInfoNew.textContent = String(srsNewCount());
     setMemView('picker');
@@ -400,12 +426,16 @@
   }
 
   function startMemSession() {
+    const cfg = loadMemConfig();
     memSess.srs          = loadSRS();
-    memSess.queue        = buildSessionQueue(memSess.srs);
+    memSess.queue        = buildSessionQueue(memSess.srs, cfg.batchSize);
     memSess.initialCount = memSess.queue.length;
     memSess.goodCount    = 0;
     memSess.againCount   = 0;
     memSess.agained      = {};
+    memSess.seenSinceQuiz = 0;
+    memSess.quizEvery = cfg.quizEvery;
+    memSess.pendingQuiz = null;
 
     if (!memSess.queue.length) {
       renderMemComplete(true);
@@ -425,14 +455,27 @@
     }
 
     memSess.currentIdx = memSess.queue.shift();
+    memSess.pendingQuiz = null;
 
     const code = STACK[memSess.currentIdx];
     const { rank, suit, isRed } = parseCard(code);
     const cardColor = isRed ? '#e0182d' : '#1a1a2e';
     const suitSym   = SUIT_SYMBOL[code[1]];
 
-    // Position number
-    els.memFaceNumber.textContent = String(memSess.currentIdx + 1);
+    const quizType = memSess.seenSinceQuiz >= memSess.quizEvery ? ['position-to-card','card-to-position','adjacent'][Math.floor(Math.random()*3)] : null;
+    if (quizType) {
+      memSess.pendingQuiz = quizType;
+      memSess.seenSinceQuiz = 0;
+    }
+    if (!memSess.pendingQuiz) memSess.seenSinceQuiz += 1;
+
+    if (memSess.pendingQuiz === 'card-to-position') {
+      els.memFaceNumber.textContent = 'What #?';
+    } else if (memSess.pendingQuiz === 'adjacent') {
+      els.memFaceNumber.textContent = `#${memSess.currentIdx + 1} + neighbor?`;
+    } else {
+      els.memFaceNumber.textContent = String(memSess.currentIdx + 1);
+    }
 
     // Playing card face
     [els.pcRank1, els.pcRank2].forEach(el => {
@@ -604,6 +647,18 @@
 
     // Memorize — start session
     els.memBtnStart.addEventListener('click', startMemSession);
+    els.memBatchSize.addEventListener('input', () => {
+      const cfg = loadMemConfig();
+      cfg.batchSize = Number(els.memBatchSize.value);
+      els.memBatchValue.textContent = String(cfg.batchSize);
+      saveMemConfig(cfg);
+    });
+    els.memQuizEvery.addEventListener('input', () => {
+      const cfg = loadMemConfig();
+      cfg.quizEvery = Number(els.memQuizEvery.value);
+      els.memQuizEveryValue.textContent = String(cfg.quizEvery);
+      saveMemConfig(cfg);
+    });
 
     // Memorize — session back
     els.btnBackSession.addEventListener('click', () => {

--- a/tools/card-stack-trainer/index.html
+++ b/tools/card-stack-trainer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover">
   <meta name="theme-color" content="#1a0b3d">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -31,7 +31,7 @@
           <span class="mode-icon">🧠</span>
           <div>
             <span class="mode-title">Stack Memorizer</span>
-            <span class="mode-copy">10 cards per session</span>
+            <span class="mode-copy" id="memModeCopy">Adaptive memory training</span>
           </div>
         </div>
         <div class="mem-mode-badge hidden" id="memModeBadge">0 due</div>
@@ -168,8 +168,19 @@
           </div>
           <div class="mem-srs-step">
             <span class="mem-srs-num">2</span>
-            <span>Try to lock in the pairing in your memory</span>
+            <span>Use active recall + spaced repetition, not passive review</span>
           </div>
+          <div class="mem-srs-step">
+            <span class="mem-srs-num">3</span>
+            <span>Intermittent mixed quizzes reinforce what you just learned</span>
+          </div>
+        </div>
+
+        <div class="mem-settings">
+          <label>Cards per session: <span id="memBatchValue">10</span></label>
+          <input id="memBatchSize" type="range" min="4" max="20" step="1" value="10">
+          <label>Quiz cadence: every <span id="memQuizEveryValue">3</span> new cards</label>
+          <input id="memQuizEvery" type="range" min="2" max="6" step="1" value="3">
         </div>
 
         <button class="btn-check mem-btn-start" id="memBtnStart">Begin Session →</button>
@@ -208,7 +219,7 @@
 
         <!-- Rating buttons (always visible) -->
         <div class="mem-rating" id="memRating">
-          <button class="mem-btn mem-btn-again" id="memBtnAgain">Repeat</button>
+          <button class="mem-btn mem-btn-again" id="memBtnAgain">Needs Work</button>
           <button class="mem-btn mem-btn-good" id="memBtnGood">Got it</button>
         </div>
       </div>

--- a/tools/card-stack-trainer/style.css
+++ b/tools/card-stack-trainer/style.css
@@ -29,6 +29,7 @@ html, body {
   background: var(--bg);
   color: var(--text);
   -webkit-tap-highlight-color: transparent;
+  touch-action: manipulation;
 }
 
 .hidden { display: none !important; }
@@ -170,6 +171,25 @@ html, body {
   color: var(--muted);
   font-size: 0.82rem;
   line-height: 1.4;
+}
+
+.mem-settings {
+  margin-top: 12px;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: var(--panel-light);
+  display: grid;
+  gap: 8px;
+}
+
+.mem-settings label {
+  color: var(--muted);
+  font-size: .9rem;
+}
+
+.mem-settings input[type="range"] {
+  width: 100%;
 }
 
 /* ── Quiz head (shared) ──────────────────────────────────────── */


### PR DESCRIPTION
### Motivation
- The existing Stack Memorizer exposed a fixed, passive flow that relied on simple linear review and a vague “Repeat” action, which is not aligned with evidence-based memory techniques. 
- Users need configurable session size and intermittent, mixed-format quizzing to reinforce active recall and spaced repetition instead of passive exposure.

### Description
- Replaced static memorizer copy and messaging to emphasize active recall, spaced repetition, and intermittent mixed quizzes, and updated the memorizer mode subtitle to reflect settings in real time (`tools/card-stack-trainer/index.html`).
- Added UI controls to the memorize picker to configure `Cards per session` (4–20) and `Quiz cadence` (every 2–6 cards), persisted via `localStorage` (`stackMemorizeConfig`) and wired to the session builder (`tools/card-stack-trainer/index.html`, `tools/card-stack-trainer/style.css`, `tools/card-stack-trainer/app.js`).
- Reworked session logic to accept a configurable batch size via `buildSessionQueue(srs, sessionSize)` and to intermittently inject mixed quiz variants (position→card, card→position, adjacent prompts) to reinforce retrieval in multiple formats (`tools/card-stack-trainer/app.js`).
- Improved UX for app-like behavior by preventing double-tap zoom with a tightened viewport meta tag and adding `touch-action: manipulation` to the stylesheet, and changed the “Repeat” label to “Needs Work” to better reflect feedback semantics (`tools/card-stack-trainer/index.html`, `tools/card-stack-trainer/style.css`).

### Testing
- Committed changes and verified repository status with `git status --short`, which showed the three modified files were staged and committed successfully. (Success)
- Attempted to capture a UI preview with `npx playwright screenshot file:///workspace/Magic-Ideas/tools/card-stack-trainer/index.html tools/card-stack-trainer/preview-memorizer.png`, but the run failed due to blocked package registry access in this environment, so automated screenshot generation could not complete. (Blocked)
- Created PR metadata via the repository tooling after the commit and verified the PR payload was produced successfully. (Success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f60c7aac8332ad72d946845a8641)