### PR TITLE
Memorize mode: adaptive chunk size, in-session recall quizzes, and UI updates

### DIFF
--- a/tools/card-stack-trainer/app.js
+++ b/tools/card-stack-trainer/app.js
@@ -49,9 +49,9 @@
   const SRS_KEY              = 'stackMemorizeSRS';
   const SRS_INTERVALS        = [1, 3, 7, 14, 30]; // days
   const MS_PER_DAY           = 86_400_000;
-  const SESSION_SIZE         = 10;
-  const MAX_DUE_PER_SESSION  = 7;
-  const MAX_REQUEUES         = 3;
+  const DEFAULT_CHUNK_SIZE   = 10;
+  const MAX_DUE_PER_SESSION  = 8;
+  const QUIZ_EVERY_N_CARDS   = 2;
 
   function loadSRS() {
     try { return JSON.parse(localStorage.getItem(SRS_KEY) || '{}'); }
@@ -68,28 +68,13 @@
     return i === -1 ? 1 : (i < SRS_INTERVALS.length - 1 ? SRS_INTERVALS[i + 1] : 30);
   }
 
-  function srsPrevInterval(cur) {
-    if (!cur || cur <= 1) return 0;
-    const i = SRS_INTERVALS.indexOf(cur);
-    return i <= 0 ? 0 : SRS_INTERVALS[i - 1];
-  }
-
-  function srsGotIt(srs, idx) {
+    function srsGotIt(srs, idx) {
     const cur         = srs[idx];
     const newInterval = srsNextInterval(cur ? cur.interval : 0);
     srs[idx] = { interval: newInterval, due: Date.now() + newInterval * MS_PER_DAY };
   }
 
-  function srsAgain(srs, idx) {
-    const cur         = srs[idx];
-    const newInterval = srsPrevInterval(cur ? cur.interval : 0);
-    srs[idx] = {
-      interval: newInterval,
-      due: newInterval > 0 ? Date.now() + newInterval * MS_PER_DAY : Date.now(),
-    };
-  }
-
-  function srsGraduatedCount() {
+    function srsGraduatedCount() {
     const srs = loadSRS();
     return STACK.filter((_, i) => srs[i] && srs[i].interval >= 1).length;
   }
@@ -105,7 +90,7 @@
     return STACK.filter((_, i) => !srs[i]).length;
   }
 
-  function buildSessionQueue(srs) {
+  function buildSessionQueue(srs, chunkSize) {
     const now = Date.now();
 
     const due = STACK
@@ -115,13 +100,13 @@
       .slice(0, MAX_DUE_PER_SESSION)
       .map(c => c.idx);
 
-    const remaining = SESSION_SIZE - due.length;
+    const remaining = chunkSize - due.length;
     const newCards  = STACK
       .map((_, i) => i)
       .filter(i => !srs[i])
       .slice(0, remaining);
 
-    // Interleave due and new cards for a natural feel
+    // Interleave due and new cards for varied retrieval practice
     const combined = [];
     const len = Math.max(due.length, newCards.length);
     for (let i = 0; i < len; i++) {
@@ -133,13 +118,15 @@
 
   /* ── Memorize session state ──────────────────────────────────── */
   const memSess = {
-    queue:        [],
+    queue: [],
     initialCount: 0,
-    goodCount:    0,
-    againCount:   0,
-    currentIdx:   null,
-    srs:          null,
-    agained:      {},   // idx → times re-queued this session (caps at 3)
+    goodCount: 0,
+    quizCount: 0,
+    currentIdx: null,
+    srs: null,
+    chunkSize: DEFAULT_CHUNK_SIZE,
+    sinceQuiz: 0,
+    quizPrompt: null,
   };
 
   /* ── DOM references ──────────────────────────────────────────── */
@@ -191,14 +178,17 @@
     memBtnStart:        document.getElementById('memBtnStart'),
     memStudyCard:       document.getElementById('memStudyCard'),
     memFaceNumber:      document.getElementById('memFaceNumber'),
-    pcRank1:            document.getElementById('pcRank1'),
-    pcSuit1:            document.getElementById('pcSuit1'),
-    pcPip:              document.getElementById('pcPip'),
-    pcRank2:            document.getElementById('pcRank2'),
-    pcSuit2:            document.getElementById('pcSuit2'),
+    pcMainRank:         document.getElementById('pcMainRank'),
+    pcMainSuit:         document.getElementById('pcMainSuit'),
     memRating:          document.getElementById('memRating'),
-    memBtnAgain:        document.getElementById('memBtnAgain'),
-    memBtnGood:         document.getElementById('memBtnGood'),
+        memBtnGood:         document.getElementById('memBtnGood'),
+    memChunkSize:       document.getElementById('memChunkSize'),
+    memChunkSizeValue:  document.getElementById('memChunkSizeValue'),
+    memQuiz:            document.getElementById('memQuiz'),
+    memQuizLabel:       document.getElementById('memQuizLabel'),
+    memQuizQuestion:    document.getElementById('memQuizQuestion'),
+    memQuizChoices:     document.getElementById('memQuizChoices'),
+    memQuizFeedback:    document.getElementById('memQuizFeedback'),
     memProgressFill:    document.getElementById('memProgressFill'),
     memCountDone:       document.getElementById('memCountDone'),
     memCountTotal:      document.getElementById('memCountTotal'),
@@ -401,11 +391,13 @@
 
   function startMemSession() {
     memSess.srs          = loadSRS();
-    memSess.queue        = buildSessionQueue(memSess.srs);
+    memSess.chunkSize    = Number(els.memChunkSize.value || DEFAULT_CHUNK_SIZE);
+    memSess.queue        = buildSessionQueue(memSess.srs, memSess.chunkSize);
     memSess.initialCount = memSess.queue.length;
     memSess.goodCount    = 0;
-    memSess.againCount   = 0;
-    memSess.agained      = {};
+    memSess.quizCount    = 0;
+    memSess.sinceQuiz    = 0;
+    els.memQuiz.classList.add('hidden');
 
     if (!memSess.queue.length) {
       renderMemComplete(true);
@@ -429,22 +421,15 @@
     const code = STACK[memSess.currentIdx];
     const { rank, suit, isRed } = parseCard(code);
     const cardColor = isRed ? '#e0182d' : '#1a1a2e';
-    const suitSym   = SUIT_SYMBOL[code[1]];
 
     // Position number
     els.memFaceNumber.textContent = String(memSess.currentIdx + 1);
 
-    // Playing card face
-    [els.pcRank1, els.pcRank2].forEach(el => {
-      el.textContent = rank;
-      el.style.color = cardColor;
-    });
-    [els.pcSuit1, els.pcSuit2].forEach(el => {
-      el.textContent = suitSym;
-      el.style.color = cardColor;
-    });
-    els.pcPip.textContent = suitSym;
-    els.pcPip.style.color = cardColor;
+    // Simplified big face
+    els.pcMainRank.textContent = rank;
+    els.pcMainSuit.textContent = suit;
+    els.pcMainRank.style.color = cardColor;
+    els.pcMainSuit.style.color = cardColor;
 
     // Animate card in
     els.memStudyCard.classList.remove('card-enter');
@@ -458,23 +443,67 @@
     srsGotIt(memSess.srs, memSess.currentIdx);
     saveSRS(memSess.srs);
     memSess.goodCount += 1;
+    memSess.sinceQuiz += 1;
     updateMasteryBar();
     updateMemModeBadge();
-    showMemCard();
+    maybeRunMemQuiz();
   }
 
-  function rateAgain() {
-    srsAgain(memSess.srs, memSess.currentIdx);
-    saveSRS(memSess.srs);
-    memSess.againCount += 1;
-    // Re-insert near the end (max 3 re-queues per card to prevent infinite loops)
-    const times = (memSess.agained[memSess.currentIdx] || 0) + 1;
-    memSess.agained[memSess.currentIdx] = times;
-    if (times <= MAX_REQUEUES) {
-      const insertAt = Math.max(0, memSess.queue.length - 2);
-      memSess.queue.splice(insertAt, 0, memSess.currentIdx);
+  function maybeRunMemQuiz() {
+    if (memSess.sinceQuiz < QUIZ_EVERY_N_CARDS || !memSess.queue.length) {
+      showMemCard();
+      return;
     }
-    showMemCard();
+    memSess.sinceQuiz = 0;
+    const idx = memSess.currentIdx;
+    const askPosition = Math.random() < 0.5;
+    const correct = askPosition ? STACK[idx] : String(idx + 1);
+
+    const allOptions = askPosition
+      ? STACK.slice()
+      : Array.from({ length: 52 }, (_, i) => String(i + 1));
+    const wrongs = allOptions.filter(v => v !== correct).sort(() => Math.random() - 0.5).slice(0, 3);
+    const options = [correct, ...wrongs].sort(() => Math.random() - 0.5);
+
+    const { rank, suit } = parseCard(STACK[idx]);
+    memSess.quizPrompt = {
+      question: askPosition ? `What is the card at #${idx + 1}?` : `What position is ${rank}${suit}?`,
+      correct,
+      askPosition,
+      options,
+    };
+
+    els.memQuizLabel.textContent = 'Retrieval check';
+    els.memQuizQuestion.textContent = memSess.quizPrompt.question;
+    els.memQuizChoices.innerHTML = '';
+    options.forEach((opt) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'mem-quiz-choice';
+      if (askPosition) {
+        const c = parseCard(opt);
+        btn.textContent = `${c.rank}${c.suit}`;
+      } else {
+        btn.textContent = `#${opt}`;
+      }
+      btn.addEventListener('click', () => checkMemQuiz(opt));
+      els.memQuizChoices.appendChild(btn);
+    });
+    els.memQuizFeedback.classList.add('hidden');
+    els.memQuiz.classList.remove('hidden');
+  }
+
+  function checkMemQuiz(selected) {
+    if (!memSess.quizPrompt) return;
+    const correct = selected === memSess.quizPrompt.correct;
+    els.memQuizFeedback.className = `feedback ${correct ? 'correct' : 'wrong'}`;
+    const answerText = memSess.quizPrompt.askPosition
+      ? (() => { const c = parseCard(memSess.quizPrompt.correct); return `${c.rank}${c.suit}`; })()
+      : `#${memSess.quizPrompt.correct}`;
+    els.memQuizFeedback.innerHTML = correct ? '✅ Nice recall.' : `❌ Correct answer: <strong>${answerText}</strong>`;
+    els.memQuizFeedback.classList.remove('hidden');
+    memSess.quizCount += 1;
+    setTimeout(() => { els.memQuiz.classList.add('hidden'); memSess.quizPrompt = null; showMemCard(); }, 700);
   }
 
   function updateMemProgress() {
@@ -495,9 +524,9 @@
       els.memCompleteTrophy.textContent = '🌟';
       els.memCompleteSub.textContent    = "Nothing due — you're all caught up!";
     } else {
-      const total = memSess.goodCount + memSess.againCount;
-      els.memCompleteTrophy.textContent = memSess.againCount === 0 ? '🏆' : '🎊';
-      els.memCompleteSub.textContent    = `You studied ${total} card${total !== 1 ? 's' : ''} this session`;
+      const total = memSess.goodCount;
+      els.memCompleteTrophy.textContent = '🏆';
+      els.memCompleteSub.textContent    = `You locked in ${total} card${total !== 1 ? 's' : ''} and completed ${memSess.quizCount} recall checks`;
     }
 
     els.memCompleteStats.innerHTML = `
@@ -506,8 +535,8 @@
         <div class="mem-stat-l">Got it ✅</div>
       </div>
       <div class="mem-stat">
-        <div class="mem-stat-n" style="color:var(--rose)">${memSess.againCount}</div>
-        <div class="mem-stat-l">Again 😓</div>
+        <div class="mem-stat-n" style="color:var(--lav)">${memSess.quizCount}</div>
+        <div class="mem-stat-l">Recall checks 🧩</div>
       </div>
       <div class="mem-stat mem-stat-wide">
         <div class="mem-stat-n">${learned}<span style="font-size:1.3rem;font-weight:600;opacity:.55"> / 52</span></div>
@@ -612,14 +641,13 @@
       setMemView('picker');
     });
 
-    // Memorize — rating buttons
-    els.memBtnAgain.addEventListener('click', rateAgain);
+    // Memorize — controls
     els.memBtnGood.addEventListener('click',  rateGood);
+    els.memChunkSize.addEventListener('input', () => { els.memChunkSizeValue.textContent = els.memChunkSize.value; });
 
     // Keyboard shortcuts for memorize session
     document.addEventListener('keydown', (e) => {
       if (els.memSession.classList.contains('hidden')) return;
-      if (e.key.toLowerCase() === 'a') { e.preventDefault(); rateAgain(); }
       if (e.key.toLowerCase() === 'g') { e.preventDefault(); rateGood(); }
     });
 

--- a/tools/card-stack-trainer/index.html
+++ b/tools/card-stack-trainer/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1, user-scalable=no">
   <meta name="theme-color" content="#1a0b3d">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
@@ -31,7 +31,7 @@
           <span class="mode-icon">🧠</span>
           <div>
             <span class="mode-title">Stack Memorizer</span>
-            <span class="mode-copy">10 cards per session</span>
+            <span class="mode-copy">Adaptive memory session</span>
           </div>
         </div>
         <div class="mem-mode-badge hidden" id="memModeBadge">0 due</div>
@@ -168,8 +168,15 @@
           </div>
           <div class="mem-srs-step">
             <span class="mem-srs-num">2</span>
-            <span>Try to lock in the pairing in your memory</span>
+            <span>Create an image/story link between position and card</span>
           </div>
+        </div>
+
+        
+        <div class="mem-settings">
+          <label for="memChunkSize">Cards per learning chunk</label>
+          <input id="memChunkSize" type="range" min="4" max="16" value="10" step="1">
+          <div class="mem-setting-value"><span id="memChunkSizeValue">10</span> cards</div>
         </div>
 
         <button class="btn-check mem-btn-start" id="memBtnStart">Begin Session →</button>
@@ -194,24 +201,23 @@
         <div class="mem-study-card" id="memStudyCard">
           <div class="mem-study-number" id="memFaceNumber">17</div>
           <div class="playing-card" id="playingCard">
-            <div class="pc-corner pc-tl">
-              <span class="pc-rank" id="pcRank1">7</span>
-              <span class="pc-suit" id="pcSuit1">♥</span>
-            </div>
-            <div class="pc-pip" id="pcPip">♥</div>
-            <div class="pc-corner pc-br">
-              <span class="pc-rank" id="pcRank2">7</span>
-              <span class="pc-suit" id="pcSuit2">♥</span>
-            </div>
+            <div class="pc-main-rank" id="pcMainRank">7</div>
+            <div class="pc-main-suit" id="pcMainSuit">♥</div>
           </div>
         </div>
 
         <!-- Rating buttons (always visible) -->
         <div class="mem-rating" id="memRating">
-          <button class="mem-btn mem-btn-again" id="memBtnAgain">Repeat</button>
           <button class="mem-btn mem-btn-good" id="memBtnGood">Got it</button>
         </div>
       </div>
+        <div class="mem-quiz hidden" id="memQuiz">
+          <div class="mem-quiz-label" id="memQuizLabel">Quick quiz</div>
+          <div class="mem-quiz-q" id="memQuizQuestion"></div>
+          <div class="mem-quiz-choices" id="memQuizChoices"></div>
+          <div class="feedback hidden" id="memQuizFeedback"></div>
+        </div>
+
 
       <!-- Complete screen -->
       <div class="hidden" id="memComplete">

--- a/tools/card-stack-trainer/style.css
+++ b/tools/card-stack-trainer/style.css
@@ -798,13 +798,13 @@ html, body {
 
 .mem-btn:active { transform: scale(0.95); }
 
-.mem-btn-again {
+.mem-btn-again-unused {
   background: linear-gradient(135deg, rgba(255, 90, 130, 0.22), rgba(255, 90, 130, 0.08));
   border: 1px solid rgba(255, 90, 130, 0.4);
   color: var(--rose);
 }
 
-.mem-btn-again:active {
+.mem-btn-again-unused:active {
   box-shadow: 0 0 0 3px rgba(255, 90, 130, 0.2);
 }
 
@@ -1154,3 +1154,26 @@ html, body {
   .question-value { font-size: 9rem; }
   .question-suit  { font-size: 5.5rem; }
 }
+
+html, body { touch-action: manipulation; }
+
+.mem-settings {
+  margin: 10px 0 14px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px;
+}
+.mem-settings label { display:block; font-weight:700; margin-bottom:8px; }
+.mem-setting-value { color: var(--muted); font-size: .9rem; margin-top: 6px; }
+.mem-quiz { margin-top: 12px; padding: 12px; border:1px solid var(--line-accent); border-radius:14px; background: var(--panel); }
+.mem-quiz-input { width:100%; margin:8px 0; padding:10px; border-radius:10px; border:1px solid var(--line); background:#0e1730; color:var(--text); }
+.mem-quiz-actions { display:flex; gap:8px; }
+
+
+.playing-card { display:flex; flex-direction:column; align-items:center; justify-content:center; gap:8px; }
+.pc-main-rank { font-size: 5.5rem; font-weight: 900; line-height: .9; }
+.pc-main-suit { font-size: 4.5rem; font-weight: 900; line-height: .9; }
+.mem-quiz-choices { display:grid; grid-template-columns:1fr 1fr; gap:8px; margin-top:10px; }
+.mem-quiz-choice { border:1px solid var(--line); background:#101a35; color:var(--text); border-radius:12px; padding:12px; font-size:1.2rem; font-weight:800; }
+.mem-quiz-choice:active { transform:scale(.97); }


### PR DESCRIPTION
### Motivation
- Make the memorization flow more adaptive by allowing variable chunk sizes and interspersed retrieval practice rather than a fixed 10-card session and a separate "again" loop.
- Simplify the study card UI and add lightweight recall checks to improve long-term retention without adding a persistent "again" rating.
- Improve mobile UX by tightening viewport settings and touch handling.

### Description
- Introduce configurable chunk size via `memChunkSize` and wire it into `buildSessionQueue(srs, chunkSize)` while replacing the old `SESSION_SIZE` with `DEFAULT_CHUNK_SIZE` and updating `MAX_DUE_PER_SESSION` and quiz pacing via `QUIZ_EVERY_N_CARDS`.
- Replace the previous "Again" SRS downgrade flow (`srsAgain` and related counters) with an in-session recall quiz system that runs every N `Got it` responses, implemented with `maybeRunMemQuiz`, `checkMemQuiz`, and UI elements under `#memQuiz` to present multiple-choice checks and feedback.
- Simplify the playing card rendering by replacing corner pip elements with a single large face (`pcMainRank`, `pcMainSuit`) and update related DOM ids and CSS classes accordingly.
- Add new UI pieces and styles: a chunk-size slider, quiz card UI (`.mem-quiz`, `.mem-quiz-choice`), touch-action optimization, and various CSS tweaks; also tighten mobile viewport with `maximum-scale=1, user-scalable=no`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8f60c7aac8332ad72d946845a8641)