### PR TITLE
Memorize: add immediate recall checks, timing, randomized order, and retry logic

### DIFF
--- a/tools/card-stack-trainer/app.js
+++ b/tools/card-stack-trainer/app.js
@@ -51,7 +51,7 @@
   const MS_PER_DAY           = 86_400_000;
   const DEFAULT_CHUNK_SIZE   = 10;
   const MAX_DUE_PER_SESSION  = 8;
-  const QUIZ_EVERY_N_CARDS   = 2;
+  const RECALL_TOO_SLOW_MS    = 2500;
 
   function loadSRS() {
     try { return JSON.parse(localStorage.getItem(SRS_KEY) || '{}'); }
@@ -90,7 +90,7 @@
     return STACK.filter((_, i) => !srs[i]).length;
   }
 
-  function buildSessionQueue(srs, chunkSize) {
+  function buildSessionQueue(srs, chunkSize, randomizeOrder) {
     const now = Date.now();
 
     const due = STACK
@@ -113,8 +113,16 @@
       if (i < due.length)      combined.push(due[i]);
       if (i < newCards.length) combined.push(newCards[i]);
     }
-    return combined;
+    return randomizeOrder ? shuffleInPlace(combined) : combined;
   }
+  function shuffleInPlace(items) {
+    for (let i = items.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [items[i], items[j]] = [items[j], items[i]];
+    }
+    return items;
+  }
+
 
   /* ── Memorize session state ──────────────────────────────────── */
   const memSess = {
@@ -125,8 +133,11 @@
     currentIdx: null,
     srs: null,
     chunkSize: DEFAULT_CHUNK_SIZE,
-    sinceQuiz: 0,
     quizPrompt: null,
+    hideCardNext: false,
+    lastRevealIdx: null,
+    lastRevealAt: 0,
+    pendingRetry: null,
   };
 
   /* ── DOM references ──────────────────────────────────────────── */
@@ -184,6 +195,7 @@
         memBtnGood:         document.getElementById('memBtnGood'),
     memChunkSize:       document.getElementById('memChunkSize'),
     memChunkSizeValue:  document.getElementById('memChunkSizeValue'),
+    memRandomizeOrder:  document.getElementById('memRandomizeOrder'),
     memQuiz:            document.getElementById('memQuiz'),
     memQuizLabel:       document.getElementById('memQuizLabel'),
     memQuizQuestion:    document.getElementById('memQuizQuestion'),
@@ -392,11 +404,14 @@
   function startMemSession() {
     memSess.srs          = loadSRS();
     memSess.chunkSize    = Number(els.memChunkSize.value || DEFAULT_CHUNK_SIZE);
-    memSess.queue        = buildSessionQueue(memSess.srs, memSess.chunkSize);
+    memSess.queue        = buildSessionQueue(memSess.srs, memSess.chunkSize, els.memRandomizeOrder.checked);
     memSess.initialCount = memSess.queue.length;
     memSess.goodCount    = 0;
     memSess.quizCount    = 0;
-    memSess.sinceQuiz    = 0;
+    memSess.hideCardNext = false;
+    memSess.lastRevealIdx = null;
+    memSess.lastRevealAt = 0;
+    memSess.pendingRetry = null;
     els.memQuiz.classList.add('hidden');
 
     if (!memSess.queue.length) {
@@ -409,6 +424,12 @@
     showMemCard();
   }
 
+  function insertQueueSoon(idx) {
+    const gap = 1 + Math.floor(Math.random() * 2);
+    const pos = Math.min(gap, memSess.queue.length);
+    memSess.queue.splice(pos, 0, idx);
+  }
+
   function showMemCard() {
     if (!memSess.queue.length) {
       renderMemComplete(false);
@@ -416,47 +437,47 @@
       return;
     }
 
-    memSess.currentIdx = memSess.queue.shift();
+    memSess.currentIdx = memSess.pendingRetry ?? memSess.queue.shift();
+    memSess.pendingRetry = null;
 
     const code = STACK[memSess.currentIdx];
     const { rank, suit, isRed } = parseCard(code);
     const cardColor = isRed ? '#e0182d' : '#1a1a2e';
 
-    // Position number
     els.memFaceNumber.textContent = String(memSess.currentIdx + 1);
-
-    // Simplified big face
     els.pcMainRank.textContent = rank;
     els.pcMainSuit.textContent = suit;
     els.pcMainRank.style.color = cardColor;
     els.pcMainSuit.style.color = cardColor;
 
-    // Animate card in
     els.memStudyCard.classList.remove('card-enter');
     void els.memStudyCard.offsetWidth;
     els.memStudyCard.classList.add('card-enter');
 
+    const isNew = !memSess.srs[memSess.currentIdx];
+    if (isNew && memSess.lastRevealIdx !== memSess.currentIdx) {
+      insertQueueSoon(memSess.currentIdx);
+      memSess.lastRevealIdx = memSess.currentIdx;
+    }
+
+    memSess.lastRevealAt = performance.now();
     updateMemProgress();
+    setTimeout(() => maybeRunMemQuiz(), 700);
   }
 
   function rateGood() {
     srsGotIt(memSess.srs, memSess.currentIdx);
     saveSRS(memSess.srs);
     memSess.goodCount += 1;
-    memSess.sinceQuiz += 1;
     updateMasteryBar();
     updateMemModeBadge();
-    maybeRunMemQuiz();
+    showMemCard();
   }
 
   function maybeRunMemQuiz() {
-    if (memSess.sinceQuiz < QUIZ_EVERY_N_CARDS || !memSess.queue.length) {
-      showMemCard();
-      return;
-    }
-    memSess.sinceQuiz = 0;
     const idx = memSess.currentIdx;
-    const askPosition = Math.random() < 0.5;
+    const askPosition = memSess.hideCardNext;
+    memSess.hideCardNext = !memSess.hideCardNext;
     const correct = askPosition ? STACK[idx] : String(idx + 1);
 
     const allOptions = askPosition
@@ -473,7 +494,7 @@
       options,
     };
 
-    els.memQuizLabel.textContent = 'Retrieval check';
+    els.memQuizLabel.textContent = askPosition ? 'Recall the card' : 'Recall the number';
     els.memQuizQuestion.textContent = memSess.quizPrompt.question;
     els.memQuizChoices.innerHTML = '';
     options.forEach((opt) => {
@@ -495,15 +516,27 @@
 
   function checkMemQuiz(selected) {
     if (!memSess.quizPrompt) return;
-    const correct = selected === memSess.quizPrompt.correct;
+    const elapsed = performance.now() - memSess.lastRevealAt;
+    const correct = selected === memSess.quizPrompt.correct && elapsed <= RECALL_TOO_SLOW_MS;
     els.memQuizFeedback.className = `feedback ${correct ? 'correct' : 'wrong'}`;
     const answerText = memSess.quizPrompt.askPosition
       ? (() => { const c = parseCard(memSess.quizPrompt.correct); return `${c.rank}${c.suit}`; })()
       : `#${memSess.quizPrompt.correct}`;
-    els.memQuizFeedback.innerHTML = correct ? '✅ Nice recall.' : `❌ Correct answer: <strong>${answerText}</strong>`;
+    els.memQuizFeedback.innerHTML = correct ? '✅ Instant recall.' : `❌ ${elapsed > RECALL_TOO_SLOW_MS ? 'Too slow. ' : ''}Correct answer: <strong>${answerText}</strong>`;
     els.memQuizFeedback.classList.remove('hidden');
     memSess.quizCount += 1;
-    setTimeout(() => { els.memQuiz.classList.add('hidden'); memSess.quizPrompt = null; showMemCard(); }, 700);
+    if (correct) {
+      rateGood();
+      setTimeout(() => { els.memQuiz.classList.add('hidden'); memSess.quizPrompt = null; }, 300);
+      return;
+    }
+
+    memSess.pendingRetry = memSess.currentIdx;
+    setTimeout(() => {
+      els.memQuiz.classList.add('hidden');
+      memSess.quizPrompt = null;
+      showMemCard();
+    }, 700);
   }
 
   function updateMemProgress() {
@@ -642,8 +675,12 @@
     });
 
     // Memorize — controls
-    els.memBtnGood.addEventListener('click',  rateGood);
+    els.memBtnGood.addEventListener('click',  () => maybeRunMemQuiz());
     els.memChunkSize.addEventListener('input', () => { els.memChunkSizeValue.textContent = els.memChunkSize.value; });
+    els.memRandomizeOrder.addEventListener('change', () => {
+      localStorage.setItem('stackMemorizeRandomOrder', els.memRandomizeOrder.checked ? '1' : '0');
+    });
+    els.memRandomizeOrder.checked = localStorage.getItem('stackMemorizeRandomOrder') === '1';
 
     // Keyboard shortcuts for memorize session
     document.addEventListener('keydown', (e) => {

--- a/tools/card-stack-trainer/index.html
+++ b/tools/card-stack-trainer/index.html
@@ -164,11 +164,11 @@
         <div class="mem-srs-how">
           <div class="mem-srs-step">
             <span class="mem-srs-num">1</span>
-            <span>See the position number and card together</span>
+            <span>See each number + card once, then recall immediately</span>
           </div>
           <div class="mem-srs-step">
             <span class="mem-srs-num">2</span>
-            <span>Create an image/story link between position and card</span>
+            <span>Recall alternates both ways (number→card and card→number)</span>
           </div>
         </div>
 
@@ -178,6 +178,11 @@
           <input id="memChunkSize" type="range" min="4" max="16" value="10" step="1">
           <div class="mem-setting-value"><span id="memChunkSizeValue">10</span> cards</div>
         </div>
+
+        <label style="display:flex;gap:8px;align-items:center;margin:10px 0 2px;opacity:.92">
+          <input id="memRandomizeOrder" type="checkbox">
+          <span>Randomize pair order for this session</span>
+        </label>
 
         <button class="btn-check mem-btn-start" id="memBtnStart">Begin Session →</button>
       </div>
@@ -208,7 +213,7 @@
 
         <!-- Rating buttons (always visible) -->
         <div class="mem-rating" id="memRating">
-          <button class="mem-btn mem-btn-good" id="memBtnGood">Got it</button>
+          <button class="mem-btn mem-btn-good" id="memBtnGood">Test me</button>
         </div>
       </div>
         <div class="mem-quiz hidden" id="memQuiz">


### PR DESCRIPTION
### Motivation
- Improve the memorize (SRS) learning flow by introducing immediate retrieval checks, enforcing a short "instant recall" threshold, and offering randomized ordering to increase retrieval practice effectiveness.
- Make the session behavior more forgiving by reinserting missed pairs for near-term retry and provide clearer quiz feedback about slow responses.

### Description
- Replace the fixed quiz-frequency mechanism with an alternating recall direction and a timing threshold by adding `RECALL_TOO_SLOW_MS` and tracking `lastRevealAt` to require fast/instant recall for full credit.
- Add an optional randomize session order controlled by a new `memRandomizeOrder` checkbox stored in `localStorage`, and change `buildSessionQueue` to accept `randomizeOrder` and optionally shuffle the combined queue via `shuffleInPlace`.
- Introduce `insertQueueSoon` and `pendingRetry` so missed items are retried soon after an incorrect recall, and update session flow to use `pendingRetry` before pulling the next queued card.
- Change UI copy and behavior: the study action button label is now "Test me" and it triggers the recall quiz (`maybeRunMemQuiz`) rather than immediately marking as learned; quiz feedback distinguishes instant recall vs slow recall and correct answers now call `rateGood()` immediately.
- Remove the old `QUIZ_EVERY_N_CARDS` / `sinceQuiz` mechanism and wire up checkbox state persistence plus initialization from `localStorage`.

### Testing
- Ran the project linter/formatter on the modified files and they passed without errors.
- Performed a build/smoke test of the web tool which exercised the memorize session, quiz flow, randomize option, and retry behavior with no runtime errors observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f96396a28c83328521b265c6303a17)